### PR TITLE
feat: add start.sh with auto-generated token/psk

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,9 @@ services:
       - --self-signed-san
       - biba-server
       - --token
-      - docker-compose-biba
+      - __BIBA_TOKEN__
       - --psk
-      - ComposePSK_ChangeMe
+      - __BIBA_PSK__
       - --decoy-max
       - "24"
       - --max-pad
@@ -39,14 +39,14 @@ services:
       - --sni
       - biba-server
       - --token
-      - docker-compose-biba
+      - __BIBA_TOKEN__
       - --insecure
       - --socks5
       - 0.0.0.0:11080
       - --http-proxy
       - 0.0.0.0:18080
       - --psk
-      - ComposePSK_ChangeMe
+      - __BIBA_PSK__
       - --decoy-max
       - "24"
       - --max-pad

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Generate random token and PSK
+TOKEN="token_$(openssl rand -hex 16)"
+PSK="PSK_$(openssl rand -hex 16)"
+
+echo "Starting BibaVPN server..."
+echo "Generated Token: $TOKEN"
+echo "Generated PSK: $PSK"
+
+# Create temporary docker-compose with generated credentials
+sed -e "s/__BIBA_TOKEN__/$TOKEN/g" \
+    -e "s/__BIBA_PSK__/$PSK/g" \
+    "$SCRIPT_DIR/docker-compose.yml" > "$SCRIPT_DIR/docker-compose.tmp.yml"
+
+# Start the server
+docker compose -f "$SCRIPT_DIR/docker-compose.tmp.yml" up -d biba-server
+
+echo ""
+echo "BibaVPN server is running on port 8443"
+echo "SOCKS5 proxy: localhost:11080"
+echo "HTTP proxy: localhost:11880"


### PR DESCRIPTION
## Summary
- Add `start.sh` script that generates random token and PSK
- Replace hardcoded credentials in `docker-compose.yml` with `__BIBA_TOKEN__` and `__BIBA_PSK__` placeholders
- Script creates temporary docker-compose file with generated credentials before running

## Usage
```bash
./start.sh
```

This starts `biba-server` via docker-compose with randomly generated credentials for security.