### PR TITLE
Add start.sh with auto-generated token and PSK

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,9 @@ services:
       - --self-signed-san
       - biba-server
       - --token
-      - docker-compose-biba
+      - __BIBA_TOKEN__
       - --psk
-      - ComposePSK_ChangeMe
+      - __BIBA_PSK__
       - --decoy-max
       - "24"
       - --max-pad

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Generate random token and PSK
+BIBA_TOKEN=$(openssl rand -hex 16)
+BIBA_PSK=$(openssl rand -hex 16)
+
+echo "Generated credentials:"
+echo "  Token: $BIBA_TOKEN"
+echo "  PSK:   $BIBA_PSK"
+
+# Replace placeholders in docker-compose.yml
+sed -e "s/__BIBA_TOKEN__/$BIBA_TOKEN/g" \
+    -e "s/__BIBA_PSK__/$BIBA_PSK/g" \
+    docker-compose.yml > docker-compose.tmp.yml
+
+echo "Starting biba-server..."
+docker compose -f docker-compose.tmp.yml up biba-server "$@"


### PR DESCRIPTION
This PR adds a start.sh script that automatically generates random token and PSK for the biba-server, replacing hardcoded values in docker-compose.yml.