### PR TITLE
Android: Yota and MegaFon in split tunnel catalog

### DIFF
--- a/android/app/src/main/java/dev/bibavpn/MainActivity.kt
+++ b/android/app/src/main/java/dev/bibavpn/MainActivity.kt
@@ -1524,6 +1524,9 @@ private fun SplitTunnelSettingsPanel() {
             )
         }
 
+        Spacer(Modifier.height(8.dp))
+        SplitTunnelOperatorDomainsPanel()
+
         if (!enabled) {
             Text(
                 stringResource(R.string.split_toggle_groups_hint),
@@ -1553,6 +1556,63 @@ private fun SplitTunnelSettingsPanel() {
                 },
             )
             Spacer(Modifier.height(12.dp))
+        }
+    }
+}
+
+@Composable
+private fun SplitTunnelOperatorDomainsPanel() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .border(1.dp, BorderSubtle, RoundedCornerShape(16.dp))
+            .background(Color(0xFF020617).copy(alpha = 0.55f))
+            .padding(16.dp),
+    ) {
+        Text(
+            stringResource(R.string.split_operator_domains_title),
+            color = Color.White,
+            fontSize = 15.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(Modifier.height(6.dp))
+        Text(
+            stringResource(R.string.split_operator_domains_sub),
+            color = TextMuted,
+            fontSize = 12.sp,
+        )
+        Spacer(Modifier.height(12.dp))
+        Text(
+            stringResource(R.string.split_operator_domains_megafon),
+            color = Mint.copy(alpha = 0.9f),
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Medium,
+        )
+        Spacer(Modifier.height(4.dp))
+        SplitTunnelOperatorDomains.megafonHosts.forEach { host ->
+            Text(
+                host,
+                color = TextMuted.copy(alpha = 0.85f),
+                fontSize = 11.sp,
+                modifier = Modifier.padding(vertical = 1.dp),
+            )
+        }
+        Spacer(Modifier.height(10.dp))
+        Text(
+            stringResource(R.string.split_operator_domains_yota),
+            color = Mint.copy(alpha = 0.9f),
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Medium,
+        )
+        Spacer(Modifier.height(4.dp))
+        SplitTunnelOperatorDomains.yotaHosts.forEach { host ->
+            Text(
+                host,
+                color = TextMuted.copy(alpha = 0.85f),
+                fontSize = 11.sp,
+                modifier = Modifier.padding(vertical = 1.dp),
+            )
         }
     }
 }

--- a/android/app/src/main/java/dev/bibavpn/SplitTunnelCatalog.kt
+++ b/android/app/src/main/java/dev/bibavpn/SplitTunnelCatalog.kt
@@ -38,6 +38,8 @@ object SplitTunnelCatalog {
             SplitTunnelApp("ru.yandex.eda", R.string.split_app_eda, SplitTunnelGroup.MARKETPLACES),
             SplitTunnelApp("com.yandex.lavka", R.string.split_app_lavka, SplitTunnelGroup.MARKETPLACES),
             SplitTunnelApp("ru.sbcs.store", R.string.split_app_samokat, SplitTunnelGroup.MARKETPLACES),
+            SplitTunnelApp("ru.dublgis.dgismobile", R.string.split_app_2gis, SplitTunnelGroup.MARKETPLACES),
+            SplitTunnelApp("ru.yandex.yandexmaps", R.string.split_app_yandex_maps, SplitTunnelGroup.MARKETPLACES),
             SplitTunnelApp("ru.megafon.mlk", R.string.split_app_megafon_mlk, SplitTunnelGroup.OPERATORS),
             SplitTunnelApp("com.megalabs.megafon.tv", R.string.split_app_megafon_tv, SplitTunnelGroup.OPERATORS),
             SplitTunnelApp("com.equeo.megafondraiv", R.string.split_app_megafon_drive, SplitTunnelGroup.OPERATORS),

--- a/android/app/src/main/java/dev/bibavpn/SplitTunnelCatalog.kt
+++ b/android/app/src/main/java/dev/bibavpn/SplitTunnelCatalog.kt
@@ -7,6 +7,7 @@ enum class SplitTunnelGroup(@StringRes val titleRes: Int) {
     GOVERNMENT(R.string.split_group_government),
     BANKS(R.string.split_group_banks),
     MARKETPLACES(R.string.split_group_marketplaces),
+    OPERATORS(R.string.split_group_operators),
 }
 
 data class SplitTunnelApp(
@@ -37,6 +38,11 @@ object SplitTunnelCatalog {
             SplitTunnelApp("ru.yandex.eda", R.string.split_app_eda, SplitTunnelGroup.MARKETPLACES),
             SplitTunnelApp("com.yandex.lavka", R.string.split_app_lavka, SplitTunnelGroup.MARKETPLACES),
             SplitTunnelApp("ru.sbcs.store", R.string.split_app_samokat, SplitTunnelGroup.MARKETPLACES),
+            SplitTunnelApp("ru.megafon.mlk", R.string.split_app_megafon_mlk, SplitTunnelGroup.OPERATORS),
+            SplitTunnelApp("com.megalabs.megafon.tv", R.string.split_app_megafon_tv, SplitTunnelGroup.OPERATORS),
+            SplitTunnelApp("com.equeo.megafondraiv", R.string.split_app_megafon_drive, SplitTunnelGroup.OPERATORS),
+            SplitTunnelApp("ru.yota.android", R.string.split_app_yota, SplitTunnelGroup.OPERATORS),
+            SplitTunnelApp("ru.yotabit.lk", R.string.split_app_yotabit, SplitTunnelGroup.OPERATORS),
         )
 
     fun allPackageNames(): Set<String> = all.map { it.packageName }.toSet()

--- a/android/app/src/main/java/dev/bibavpn/SplitTunnelOperatorDomains.kt
+++ b/android/app/src/main/java/dev/bibavpn/SplitTunnelOperatorDomains.kt
@@ -1,0 +1,34 @@
+package dev.bibavpn
+
+/**
+ * Официальные и часто используемые хосты операторов (для справки в UI).
+ * Сплит-туннель в Android обходит VPN только для **приложений** ([addDisallowedApplication]);
+ * трафик браузера к этим доменам не исключается автоматически.
+ */
+object SplitTunnelOperatorDomains {
+    val megafonHosts: List<String> =
+        listOf(
+            "api.megafon.ru",
+            "corp.megafon.ru",
+            "dom.megafon.ru",
+            "drive.megafon.ru",
+            "lk.megafon.ru",
+            "megafon.ru",
+            "megafon.tv",
+            "payment.megafon.ru",
+            "static.megafon.ru",
+            "tv.megafon.tv",
+            "www.megafon.ru",
+            "www.megafon.tv",
+        ).distinct().sorted()
+
+    val yotaHosts: List<String> =
+        listOf(
+            "api.yota.ru",
+            "my.yota.ru",
+            "shop.yota.ru",
+            "static.yota.ru",
+            "www.yota.ru",
+            "yota.ru",
+        ).distinct().sorted()
+}

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -111,6 +111,11 @@
     <string name="split_group_government">Government</string>
     <string name="split_group_banks">Banks</string>
     <string name="split_group_marketplaces">Marketplaces</string>
+    <string name="split_group_operators">Carriers (Yota, MegaFon)</string>
+    <string name="split_operator_domains_title">Operator domains (reference)</string>
+    <string name="split_operator_domains_sub">These are official sites and APIs. VPN bypass applies to apps in the list; browser traffic still uses the tunnel unless you disconnect or configure the browser separately.</string>
+    <string name="split_operator_domains_megafon">MegaFon</string>
+    <string name="split_operator_domains_yota">Yota</string>
     <string name="split_app_gosuslugi">Public services</string>
     <string name="split_app_max">MAX</string>
     <string name="split_app_vk">VK</string>
@@ -130,6 +135,11 @@
     <string name="split_app_eda">Yandex Eda</string>
     <string name="split_app_lavka">Yandex Lavka</string>
     <string name="split_app_samokat">Samokat</string>
+    <string name="split_app_megafon_mlk">MegaFon</string>
+    <string name="split_app_megafon_tv">MegaFon TV</string>
+    <string name="split_app_megafon_drive">MegaFon Drive</string>
+    <string name="split_app_yota">Yota</string>
+    <string name="split_app_yotabit">Yotabit (cable)</string>
 
     <string name="vpn_error_tun2socks">tun2socks error</string>
     <string name="vpn_error_prefix">BibaVPN: %1$s</string>

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -135,6 +135,8 @@
     <string name="split_app_eda">Yandex Eda</string>
     <string name="split_app_lavka">Yandex Lavka</string>
     <string name="split_app_samokat">Samokat</string>
+    <string name="split_app_2gis">2GIS</string>
+    <string name="split_app_yandex_maps">Yandex Maps</string>
     <string name="split_app_megafon_mlk">MegaFon</string>
     <string name="split_app_megafon_tv">MegaFon TV</string>
     <string name="split_app_megafon_drive">MegaFon Drive</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -110,6 +110,11 @@
     <string name="split_group_government">Gubernamentales</string>
     <string name="split_group_banks">Bancos</string>
     <string name="split_group_marketplaces">Marketplaces</string>
+    <string name="split_group_operators">Operadores (Yota, MegaFon)</string>
+    <string name="split_operator_domains_title">Dominios del operador (referencia)</string>
+    <string name="split_operator_domains_sub">Sitios y API oficiales. La exclusión de VPN aplica a las apps de la lista; el navegador sigue usando el túnel salvo que desconectes o configures el navegador aparte.</string>
+    <string name="split_operator_domains_megafon">MegaFon</string>
+    <string name="split_operator_domains_yota">Yota</string>
     <string name="split_app_gosuslugi">Servicios públicos</string>
     <string name="split_app_max">MAX</string>
     <string name="split_app_vk">VK</string>
@@ -129,6 +134,11 @@
     <string name="split_app_eda">Yandex Eda</string>
     <string name="split_app_lavka">Yandex Lavka</string>
     <string name="split_app_samokat">Samokat</string>
+    <string name="split_app_megafon_mlk">MegaFon</string>
+    <string name="split_app_megafon_tv">MegaFon TV</string>
+    <string name="split_app_megafon_drive">MegaFon Drive</string>
+    <string name="split_app_yota">Yota</string>
+    <string name="split_app_yotabit">Yotabit (cable)</string>
 
     <string name="vpn_error_tun2socks">error de tun2socks</string>
     <string name="vpn_error_prefix">BibaVPN: %1$s</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -134,6 +134,8 @@
     <string name="split_app_eda">Yandex Eda</string>
     <string name="split_app_lavka">Yandex Lavka</string>
     <string name="split_app_samokat">Samokat</string>
+    <string name="split_app_2gis">2GIS</string>
+    <string name="split_app_yandex_maps">Yandex Maps</string>
     <string name="split_app_megafon_mlk">MegaFon</string>
     <string name="split_app_megafon_tv">MegaFon TV</string>
     <string name="split_app_megafon_drive">MegaFon Drive</string>

--- a/android/app/src/main/res/values-fa-rIR/strings.xml
+++ b/android/app/src/main/res/values-fa-rIR/strings.xml
@@ -111,6 +111,11 @@
     <string name="split_group_government">دولتی</string>
     <string name="split_group_banks">بانک‌ها</string>
     <string name="split_group_marketplaces">بازار و خدمات محلی</string>
+    <string name="split_group_operators">اپراتورها (Yota، MegaFon)</string>
+    <string name="split_operator_domains_title">دامنه‌های اپراتور (مرجع)</string>
+    <string name="split_operator_domains_sub">سایت‌ها و APIهای رسمی. دور زدن VPN فقط برای برنامه‌های فهرست است؛ ترافیک مرورگر همچنان از تونل می‌گذرد مگر VPN را قطع کنید یا مرورگر را جداگانه تنظیم کنید.</string>
+    <string name="split_operator_domains_megafon">MegaFon</string>
+    <string name="split_operator_domains_yota">Yota</string>
     <string name="split_app_gosuslugi">خدمات دولتی</string>
     <string name="split_app_max">MAX</string>
     <string name="split_app_vk">VK</string>
@@ -130,6 +135,11 @@
     <string name="split_app_eda">Yandex Eda</string>
     <string name="split_app_lavka">Yandex Lavka</string>
     <string name="split_app_samokat">Samokat</string>
+    <string name="split_app_megafon_mlk">MegaFon</string>
+    <string name="split_app_megafon_tv">MegaFon TV</string>
+    <string name="split_app_megafon_drive">MegaFon Drive</string>
+    <string name="split_app_yota">Yota</string>
+    <string name="split_app_yotabit">Yotabit (کابل)</string>
 
     <string name="vpn_error_tun2socks">خطای tun2socks</string>
     <string name="vpn_error_prefix">BibaVPN: %1$s</string>

--- a/android/app/src/main/res/values-fa-rIR/strings.xml
+++ b/android/app/src/main/res/values-fa-rIR/strings.xml
@@ -135,6 +135,8 @@
     <string name="split_app_eda">Yandex Eda</string>
     <string name="split_app_lavka">Yandex Lavka</string>
     <string name="split_app_samokat">Samokat</string>
+    <string name="split_app_2gis">2GIS</string>
+    <string name="split_app_yandex_maps">Yandex Maps</string>
     <string name="split_app_megafon_mlk">MegaFon</string>
     <string name="split_app_megafon_tv">MegaFon TV</string>
     <string name="split_app_megafon_drive">MegaFon Drive</string>

--- a/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -110,6 +110,11 @@
     <string name="split_group_government">政务</string>
     <string name="split_group_banks">银行</string>
     <string name="split_group_marketplaces">电商与本地服务</string>
+    <string name="split_group_operators">运营商（Yota、MegaFon）</string>
+    <string name="split_operator_domains_title">运营商域名（参考）</string>
+    <string name="split_operator_domains_sub">以下为官方网站与 API。VPN 绕行仅对列表中的应用生效；浏览器流量仍会走隧道，除非断开 VPN 或为浏览器单独设置。</string>
+    <string name="split_operator_domains_megafon">MegaFon</string>
+    <string name="split_operator_domains_yota">Yota</string>
     <string name="split_app_gosuslugi">国家服务</string>
     <string name="split_app_max">MAX</string>
     <string name="split_app_vk">VK</string>
@@ -129,6 +134,11 @@
     <string name="split_app_eda">Yandex Eda</string>
     <string name="split_app_lavka">Yandex Lavka</string>
     <string name="split_app_samokat">Samokat</string>
+    <string name="split_app_megafon_mlk">MegaFon</string>
+    <string name="split_app_megafon_tv">MegaFon TV</string>
+    <string name="split_app_megafon_drive">MegaFon Drive</string>
+    <string name="split_app_yota">Yota</string>
+    <string name="split_app_yotabit">Yotabit（有线）</string>
 
     <string name="vpn_error_tun2socks">tun2socks 错误</string>
     <string name="vpn_error_prefix">BibaVPN：%1$s</string>

--- a/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -134,6 +134,8 @@
     <string name="split_app_eda">Yandex Eda</string>
     <string name="split_app_lavka">Yandex Lavka</string>
     <string name="split_app_samokat">Samokat</string>
+    <string name="split_app_2gis">2GIS</string>
+    <string name="split_app_yandex_maps">Yandex 地图</string>
     <string name="split_app_megafon_mlk">MegaFon</string>
     <string name="split_app_megafon_tv">MegaFon TV</string>
     <string name="split_app_megafon_drive">MegaFon Drive</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -135,6 +135,8 @@
     <string name="split_app_eda">Яндекс Еда</string>
     <string name="split_app_lavka">Яндекс Лавка</string>
     <string name="split_app_samokat">Самокат</string>
+    <string name="split_app_2gis">2ГИС</string>
+    <string name="split_app_yandex_maps">Яндекс Карты</string>
     <string name="split_app_megafon_mlk">МегаФон</string>
     <string name="split_app_megafon_tv">МегаФон ТВ</string>
     <string name="split_app_megafon_drive">МегаФон Драйв</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -111,6 +111,11 @@
     <string name="split_group_government">Государственные</string>
     <string name="split_group_banks">Банки</string>
     <string name="split_group_marketplaces">Маркетплейсы</string>
+    <string name="split_group_operators">Операторы (Yota, МегаФон)</string>
+    <string name="split_operator_domains_title">Домены операторов (справка)</string>
+    <string name="split_operator_domains_sub">Ниже — официальные сайты и API. Обход VPN действует на приложения из списка; сайты в браузере по-прежнему идут через туннель, пока не отключите VPN или не настроите браузер отдельно.</string>
+    <string name="split_operator_domains_megafon">МегаФон</string>
+    <string name="split_operator_domains_yota">Yota</string>
     <string name="split_app_gosuslugi">Госуслуги</string>
     <string name="split_app_max">MAX</string>
     <string name="split_app_vk">ВКонтакте</string>
@@ -130,6 +135,11 @@
     <string name="split_app_eda">Яндекс Еда</string>
     <string name="split_app_lavka">Яндекс Лавка</string>
     <string name="split_app_samokat">Самокат</string>
+    <string name="split_app_megafon_mlk">МегаФон</string>
+    <string name="split_app_megafon_tv">МегаФон ТВ</string>
+    <string name="split_app_megafon_drive">МегаФон Драйв</string>
+    <string name="split_app_yota">Yota</string>
+    <string name="split_app_yotabit">Yotabit (кабель)</string>
 
     <string name="vpn_error_tun2socks">ошибка tun2socks</string>
     <string name="vpn_error_prefix">BibaVPN: %1$s</string>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds an **Operators** group to the split-tunnel preset list with official Android package IDs for **MegaFon** (`ru.megafon.mlk`, `com.megalabs.megafon.tv`, `com.equeo.megafondraiv`), **Yota** (`ru.yota.android`), and **Yotabit** cable LK (`ru.yotabit.lk`).
- Adds **2GIS** (`ru.dublgis.dgismobile`) and **Yandex Maps** (`ru.yandex.yandexmaps`) under the marketplaces / local services group.
- Adds a **reference panel** on the split-tunnel tab listing common **megafon.ru / megafon.tv** and **yota.ru** hostnames, with copy clarifying that Android per-app bypass does not automatically exclude browser traffic to those domains.

## Context

Split tunneling in this app is implemented with `VpnService.Builder.addDisallowedApplication` for selected packages; there is no built-in domain-based split in the VPN layer. The domain list is documented in-app for users who need to know operator endpoints.

## Testing

- `./gradlew :app:compileDebugKotlin` could not run in the agent environment (no Android SDK / `ANDROID_HOME`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d15e0931-8bf3-44c0-9d6d-2879d6b9a151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d15e0931-8bf3-44c0-9d6d-2879d6b9a151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

