### PR TITLE
fix(android): установка Tauri APK на Android TV

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -125,7 +125,7 @@ jobs:
           npm run build --prefix ./ui
           attempt=1
           until [ "$attempt" -gt 3 ]; do
-            npx tauri android build --debug --ci -t aarch64 && exit 0
+            npx tauri android build --debug --ci && exit 0
             attempt=$((attempt + 1))
             sleep 30
           done

--- a/apps/bibavpn-desktop/src-tauri/android-bibavpn-extras/res/drawable/tv_banner.xml
+++ b/apps/bibavpn-desktop/src-tauri/android-bibavpn-extras/res/drawable/tv_banner.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Android TV launcher banner (320x180 dp). Background: DESIGN.md tvBannerBg (#0B0F1A). -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#0B0F1A" />
+        </shape>
+    </item>
+    <item
+        android:width="96dp"
+        android:height="96dp"
+        android:gravity="center">
+        <bitmap android:src="@mipmap/ic_launcher" />
+    </item>
+</layer-list>

--- a/apps/scripts/integrate-bibavpn-into-tauri-android.sh
+++ b/apps/scripts/integrate-bibavpn-into-tauri-android.sh
@@ -23,6 +23,7 @@ cp -f "$EXTRAS/java/dev/bibavpn/core/VpnProtect.kt" "$APP_JAVA/core/"
 
 mkdir -p "$GEN/app/src/main/res/drawable"
 cp -f "$EXTRAS/res/drawable/ic_stat_vpn.xml" "$GEN/app/src/main/res/drawable/"
+cp -f "$EXTRAS/res/drawable/tv_banner.xml" "$GEN/app/src/main/res/drawable/"
 
 # Строки только для VPN-уведомлений (не перетираем strings Tauri)
 EXR="$EXTRAS/res"

--- a/apps/scripts/merge_bibavpn_manifest.py
+++ b/apps/scripts/merge_bibavpn_manifest.py
@@ -1,4 +1,4 @@
-"""Дописывает в Tauri AndroidManifest разрешения, AppLocales (AppCompat) и BibaVpnService."""
+"""Дописывает в Tauri AndroidManifest разрешения, TV-совместимость, AppLocales и BibaVpnService."""
 import pathlib
 import re
 import sys
@@ -10,6 +10,18 @@ PERMS = """
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+"""
+
+# Без touchscreen required=false Android TV часто отклоняет установку («Приложение не установлено»).
+TV_FEATURES = """
+    <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+    <uses-feature android:name="android.hardware.faketouch" android:required="false" />
+    <uses-feature android:name="android.hardware.telephony" android:required="false" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.microphone" android:required="false" />
+    <uses-feature android:name="android.hardware.location" android:required="false" />
+    <uses-feature android:name="android.hardware.location.gps" android:required="false" />
+    <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
 """
 
 # Нужен для setApplicationLocales / AppCompat; без meta лог: AppLocalesMetadataHolderService not found
@@ -39,34 +51,88 @@ SERVICE = """
         </service>
 """
 
+PICK_PACKAGE_ACTIVITY = """
+        <activity
+            android:name=".PickInstalledPackageActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Dialog" />
+"""
+
+
+def _insert_after_internet_perm(text: str, block: str) -> str:
+    if block.strip() in text:
+        return text
+    needle = '<uses-permission android:name="android.permission.INTERNET" />'
+    if needle not in text:
+        return text
+    return text.replace(needle, needle + block, 1)
+
+
+def _ensure_tv_features(text: str) -> str:
+    if 'android.hardware.touchscreen' in text:
+        return text
+    if 'android.software.leanback' in text:
+        return text.replace(
+            '<uses-feature android:name="android.software.leanback" android:required="false" />',
+            '<uses-feature android:name="android.software.leanback" android:required="false" />' + TV_FEATURES,
+            1,
+        )
+    return _insert_after_internet_perm(text, TV_FEATURES)
+
+
+def _ensure_tv_banner(text: str) -> str:
+    if 'android:banner=' in text:
+        return text
+    return re.sub(
+        r"(<application\s)",
+        r'\1android:banner="@drawable/tv_banner" ',
+        text,
+        count=1,
+    )
+
+
+def _ensure_biba_application(text: str) -> str:
+    if 'android:name=".BibaApplication"' in text:
+        return text
+    return text.replace(
+        "<application",
+        '<application\n        android:name=".BibaApplication"',
+        1,
+    )
+
+
+def patch_manifest(text: str) -> tuple[str, bool]:
+    original = text
+    text = _insert_after_internet_perm(text, PERMS)
+    text = _ensure_tv_features(text)
+    text = _ensure_tv_banner(text)
+    text = _ensure_biba_application(text)
+
+    if "AppLocalesMetadataHolderService" not in text:
+        text = re.sub(
+            r"(<application\s[^>]*>)",
+            r"\1" + APP_LOCALES_SERVICE,
+            text,
+            count=1,
+        )
+
+    if "BibaVpnService" not in text:
+        text = re.sub(r"(</application>)", SERVICE + r"\1", text, count=1)
+
+    if "PickInstalledPackageActivity" not in text:
+        text = re.sub(r"(</application>)", PICK_PACKAGE_ACTIVITY + r"\1", text, count=1)
+
+    return text, text != original
+
 
 def main() -> None:
     path = pathlib.Path(sys.argv[1])
-    t = path.read_text(encoding="utf-8")
-    has_vpn = "BibaVpnService" in t
-    has_locales = "AppLocalesMetadataHolderService" in t
-    if has_vpn and has_locales:
+    patched, changed = patch_manifest(path.read_text(encoding="utf-8"))
+    if changed:
+        path.write_text(patched, encoding="utf-8")
+        print("manifest patched")
+    else:
         print("manifest already patched")
-        return
-    if "ACCESS_NETWORK_STATE" not in t:
-        t = t.replace(
-            '<uses-permission android:name="android.permission.INTERNET" />',
-            '<uses-permission android:name="android.permission.INTERNET" />' + PERMS,
-            1,
-        )
-    if not has_locales:
-        t = re.sub(
-            r"(<application\s[^>]*>)",
-            r"\1" + APP_LOCALES_SERVICE,
-            t,
-            count=1,
-        )
-    if not has_vpn:
-        t = re.sub(r"(</application>)", SERVICE + r"\1", t, count=1)
-    if 'android:name=".BibaApplication"' not in t:
-        t = t.replace("<application", '<application\n        android:name=".BibaApplication"', 1)
-    path.write_text(t, encoding="utf-8")
-    print("manifest patched")
 
 
 if __name__ == "__main__":

--- a/apps/scripts/test_merge_bibavpn_manifest.py
+++ b/apps/scripts/test_merge_bibavpn_manifest.py
@@ -1,0 +1,53 @@
+"""Smoke tests for merge_bibavpn_manifest.patch_manifest."""
+from merge_bibavpn_manifest import patch_manifest
+
+SAMPLE = """<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- AndroidTV support -->
+    <uses-feature android:name="android.software.leanback" android:required="false" />
+
+    <application
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:theme="@style/Theme.bibavpn_desktop"
+        android:usesCleartextTraffic="${usesCleartextTraffic}">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>
+"""
+
+
+def test_adds_touchscreen_not_required() -> None:
+    patched, changed = patch_manifest(SAMPLE)
+    assert changed
+    assert 'android.hardware.touchscreen" android:required="false"' in patched
+
+
+def test_adds_tv_banner() -> None:
+    patched, _ = patch_manifest(SAMPLE)
+    assert 'android:banner="@drawable/tv_banner"' in patched
+
+
+def test_idempotent() -> None:
+    first, changed1 = patch_manifest(SAMPLE)
+    second, changed2 = patch_manifest(first)
+    assert changed1
+    assert not changed2
+    assert first == second
+
+
+if __name__ == "__main__":
+    test_adds_touchscreen_not_required()
+    test_adds_tv_banner()
+    test_idempotent()
+    print("ok")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Проблема

На Android TV при установке нового Tauri APK появлялось сообщение «Приложение не установлено».

## Причины

1. **Манифест** — не было `android.hardware.touchscreen required=false` и других TV-friendly `uses-feature`. Tauri добавляет `LEANBACK_LAUNCHER`, но без явного «touchscreen не обязателен» TV часто отклоняет установку.
2. **ABI** — CI собирал только **arm64**. На приставках с **armeabi-v7a** или **x86/x86_64** APK не содержал нужных `.so` → `INSTALL_FAILED_NO_MATCHING_ABIS`.

## Изменения

- `merge_bibavpn_manifest.py`: TV `uses-feature`, `android:banner`, idempotent-патч даже если VPN-сервис уже добавлен
- `tv_banner.xml` + копирование в integrate-скрипте
- CI (`android.yml`): universal APK со всеми ABI (JNI + Tauri build без `-t aarch64`)
- Smoke-тесты для manifest merge

## Как проверить на TV

1. Дождаться CI-артефакт `BibaVPN-android-debug.apk` или пересобрать локально:
   ```bash
   bash apps/scripts/tauri-android-init-local.sh
   bash apps/scripts/integrate-bibavpn-into-tauri-android.sh
   bash apps/scripts/wsl-build-tauri-android-jni.sh
   cd apps/bibavpn-desktop && npm run tauri:android:build
   ```
2. Если старая версия уже стояла с **другой подписью** — сначала удалите её (Настройки → Приложения).
3. Установите новый universal APK.

## Примечание

Если после обновления установка всё ещё падает — проверьте, что удалена предыдущая сборка с другим keystore (debug vs release).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0217afa0-d1ca-4c61-a974-009fbaaf9893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0217afa0-d1ca-4c61-a974-009fbaaf9893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

