### PR TITLE
fix(apps): таймаут 2 с для API списков обхода

### DIFF
--- a/apps/bibavpn-desktop/src-tauri/src/bypass_domains.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/bypass_domains.rs
@@ -14,6 +14,8 @@ use tracing::{info, warn};
 
 const USER_AGENT: &str = "bibavpn-desktop/1.0";
 const DEFAULT_TTL_SEC: u64 = 86_400;
+/// Max wait for connect + response body when fetching bypass lists (fail fast; use disk cache).
+pub const HTTP_TIMEOUT_SECS: u64 = 2;
 /// When the bulk JSON stalls (~17 KiB on the origin), fetch each preset via `?preset=`.
 const FALLBACK_PRESET_IDS: &[&str] = &[
     "gosuslugi",
@@ -259,10 +261,11 @@ fn parse_api_response(body: &str) -> Result<(Vec<BypassPresetInfo>, u64), String
     }
 }
 
-fn http_agent(read_timeout_secs: u64) -> ureq::Agent {
+fn http_agent() -> ureq::Agent {
+    let timeout = Duration::from_secs(HTTP_TIMEOUT_SECS);
     ureq::AgentBuilder::new()
-        .timeout_read(Duration::from_secs(read_timeout_secs))
-        .timeout_connect(Duration::from_secs(15))
+        .timeout_read(timeout)
+        .timeout_connect(timeout)
         .user_agent(USER_AGENT)
         .build()
 }
@@ -298,13 +301,13 @@ fn fetch_http_body(agent: &ureq::Agent, url: &str) -> Result<String, String> {
 }
 
 fn fetch_remote_bulk(url: &str) -> Result<(Vec<BypassPresetInfo>, u64), String> {
-    let agent = http_agent(45);
+    let agent = http_agent();
     let body = fetch_http_body(&agent, url)?;
     parse_api_response(&body)
 }
 
 fn fetch_remote_presets(base_url: &str) -> Result<(Vec<BypassPresetInfo>, u64), String> {
-    let agent = http_agent(30);
+    let agent = http_agent();
     let mut presets = Vec::new();
     let mut errors = Vec::new();
     for (i, id) in FALLBACK_PRESET_IDS.iter().enumerate() {
@@ -337,19 +340,24 @@ fn fetch_remote_presets(base_url: &str) -> Result<(Vec<BypassPresetInfo>, u64), 
     Ok((presets, DEFAULT_TTL_SEC))
 }
 
+/// Single bulk request (or one preset URL). Used on the UI/connect hot path — max [`HTTP_TIMEOUT_SECS`].
 fn fetch_remote(url: &str) -> Result<(Vec<BypassPresetInfo>, u64), String> {
     if url_has_preset_filter(url) {
-        let agent = http_agent(30);
+        let agent = http_agent();
         let body = fetch_http_body(&agent, url)?;
         return parse_api_response(&body);
     }
-    match fetch_remote_bulk(url) {
+    fetch_remote_bulk(url)
+}
+
+fn refresh_from_network_with_fallback(url: &str) -> Result<(Vec<BypassPresetInfo>, u64), String> {
+    match fetch_remote(url) {
         Ok(result) => Ok(result),
         Err(bulk_err) => {
             warn!(
                 target: "bibavpn_desktop",
                 error = %bulk_err,
-                "bypass-domains bulk fetch failed, trying per-preset"
+                "bypass-domains bulk fetch failed, trying per-preset (background)"
             );
             fetch_remote_presets(url)
                 .map_err(|fallback_err| format!("{bulk_err}; per-preset fallback: {fallback_err}"))
@@ -362,6 +370,29 @@ fn cache_is_fresh(state: &CacheState) -> bool {
         return false;
     };
     at.elapsed().unwrap_or(Duration::MAX) < state.ttl
+}
+
+/// Background-only refresh (bulk, then per-preset fallback). Does not block the UI or connect path.
+pub fn background_refresh_full() {
+    let Some(url) = bypass_domains_url() else {
+        return;
+    };
+    match refresh_from_network_with_fallback(&url) {
+        Ok((presets, ttl)) => {
+            save_disk_cache(&url, ttl, &presets);
+            if let Ok(mut state) = cache_lock().lock() {
+                apply_presets(&mut state, presets.clone(), ttl, &url);
+                info!(
+                    target: "bibavpn_desktop",
+                    count = presets.len(),
+                    "bypass-domains: background refresh ok"
+                );
+            }
+        }
+        Err(e) => {
+            warn!(target: "bibavpn_desktop", "bypass-domains background refresh: {e}");
+        }
+    }
 }
 
 /// Load presets from memory, disk, or network (in that order when stale).
@@ -410,7 +441,7 @@ pub fn ensure_loaded(force_refresh: bool) -> Result<Vec<BypassPresetInfo>, Strin
                 apply_presets(&mut state, file.presets.clone(), file.ttl_sec, &url);
                 return Ok(state.presets.clone());
             }
-            Err(e)
+            Ok(Vec::new())
         }
     }
 }
@@ -459,8 +490,7 @@ pub fn cached_domains_for_preset_ids(ids: &[String]) -> Vec<String> {
 }
 
 pub fn domains_for_preset_ids(ids: &[String]) -> Vec<String> {
-    let _ = ensure_loaded(false);
-    domains_for_preset_ids_from_cache(ids)
+    cached_domains_for_preset_ids(ids)
 }
 
 fn android_packages_for_preset_ids_from_cache(ids: &[String]) -> Vec<String> {
@@ -486,9 +516,12 @@ fn android_packages_for_preset_ids_from_cache(ids: &[String]) -> Vec<String> {
     out
 }
 
-pub fn android_packages_for_preset_ids(ids: &[String]) -> Vec<String> {
-    let _ = ensure_loaded(false);
+pub fn cached_android_packages_for_preset_ids(ids: &[String]) -> Vec<String> {
     android_packages_for_preset_ids_from_cache(ids)
+}
+
+pub fn android_packages_for_preset_ids(ids: &[String]) -> Vec<String> {
+    cached_android_packages_for_preset_ids(ids)
 }
 
 #[cfg(test)]

--- a/apps/bibavpn-desktop/src-tauri/src/lib.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/lib.rs
@@ -588,7 +588,6 @@ fn connect_inner(state: &AppState, app: &AppHandle) -> Result<(), String> {
 
     let http_hp = format!("127.0.0.1:{http_port}");
     let socks_hp = format!("127.0.0.1:{socks_port}");
-    let _ = bypass_domains::ensure_loaded(false);
     let split_hosts = g
         .cfg
         .active_profile()
@@ -652,7 +651,6 @@ fn connect_inner(state: &AppState, app: &AppHandle) -> Result<(), String> {
 
     persist_cfg(app, &g.cfg)?;
     let json = g.cfg.start_config_json()?;
-    let _ = bypass_domains::ensure_loaded(false);
     let (split_tunnel_enabled, packages, battery) = match g.cfg.active_profile() {
         Some(p) => (
             p.split_tunnel_enabled,
@@ -858,38 +856,57 @@ struct BypassPresetsResponse {
 
 #[tauri::command]
 async fn get_bypass_presets_cmd(refresh: bool) -> BypassPresetsResponse {
-    match tauri::async_runtime::spawn_blocking(move || {
+    const FETCH_TIMEOUT: Duration =
+        Duration::from_secs(bypass_domains::HTTP_TIMEOUT_SECS + 1);
+
+    let task = tauri::async_runtime::spawn_blocking(move || {
         let configured = bypass_domains::bypass_domains_url().is_some();
         match bypass_domains::ensure_loaded(refresh) {
-            Ok(presets) => BypassPresetsResponse {
-                presets,
-                configured,
-                error: None,
-            },
+            Ok(presets) => {
+                let error = if configured && presets.is_empty() {
+                    Some(
+                        "Списки обхода недоступны (таймаут 2 с или ошибка сети)".into(),
+                    )
+                } else {
+                    None
+                };
+                BypassPresetsResponse {
+                    presets,
+                    configured,
+                    error,
+                }
+            }
             Err(e) => BypassPresetsResponse {
                 presets: bypass_domains::cached_presets_or_empty(),
                 configured,
                 error: Some(e),
             },
         }
-    })
-    .await
-    {
-        Ok(response) => response,
-        Err(e) => BypassPresetsResponse {
+    });
+
+    match tokio::time::timeout(FETCH_TIMEOUT, task).await {
+        Ok(Ok(response)) => response,
+        Ok(Err(e)) => BypassPresetsResponse {
             presets: bypass_domains::cached_presets_or_empty(),
             configured: bypass_domains::bypass_domains_url().is_some(),
             error: Some(format!("bypass presets task: {e}")),
+        },
+        Err(_) => BypassPresetsResponse {
+            presets: bypass_domains::cached_presets_or_empty(),
+            configured: bypass_domains::bypass_domains_url().is_some(),
+            error: Some("Таймаут загрузки списков обхода (2 с)".into()),
         },
     }
 }
 
 fn prefetch_bypass_domains() {
     std::thread::spawn(|| {
-        if bypass_domains::bypass_domains_url().is_some() {
-            if let Err(e) = bypass_domains::ensure_loaded(false) {
-                warn!(target: "bibavpn_desktop", "prefetch bypass-domains: {e}");
-            }
+        if bypass_domains::bypass_domains_url().is_none() {
+            return;
+        }
+        let _ = bypass_domains::ensure_loaded(false);
+        if bypass_domains::cached_presets_or_empty().is_empty() {
+            bypass_domains::background_refresh_full();
         }
     });
 }

--- a/apps/bibavpn-desktop/src-tauri/src/split_tunnel.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/split_tunnel.rs
@@ -17,7 +17,7 @@ pub fn android_split_packages_for_profile(profile: &TunnelProfile) -> Vec<String
     if !profile.split_tunnel_enabled {
         return Vec::new();
     }
-    let mut out = bypass_domains::android_packages_for_preset_ids(&profile.split_tunnel_preset_ids);
+    let mut out = bypass_domains::cached_android_packages_for_preset_ids(&profile.split_tunnel_preset_ids);
     for pkg in &profile.android_manual_split_packages {
         let k = pkg.trim();
         if !k.is_empty() && !out.iter().any(|x| x == k) {

--- a/apps/bibavpn-desktop/ui/src/useBypassPresets.js
+++ b/apps/bibavpn-desktop/ui/src/useBypassPresets.js
@@ -35,6 +35,7 @@ export function useBypassPresets() {
       setConfigured(Boolean(res.configured));
       setError(res.error || null);
     } catch (e) {
+      setPresets([]);
       setError(String(e));
     } finally {
       setLoading(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Загрузка списков split-tunnel из control-plane API больше не блокирует приложение и обрывается через 2 секунды, если сервер недоступен или отвечает слишком долго.

## Changes

- **HTTP-таймауты** (`bypass_domains.rs`): connect и read — **2 с** (раньше 15–45 с).
- **Горячий путь (UI / connect)**: один bulk-запрос с таймаутом; per-preset fallback только в фоне при prefetch.
- **Подключение VPN**: убран синхронный `ensure_loaded` — используются домены/пакеты из кэша на диске или в памяти.
- **Tauri-команда `get_bypass_presets_cmd`**: обёрнута в `tokio::time::timeout(3s)`; при ошибке возвращает кэш или пустой список.
- **Graceful degradation**: если API недоступен и кэша нет — пустой список + сообщение в настройках, приложение и VPN продолжают работать.
- **UI** (`useBypassPresets.js`): при исключении сбрасывает presets в `[]`.

## Testing

- Локальная сборка `bibavpn-desktop` на Linux требует GTK (не доступен в cloud runner).
- Юнит-тесты парсинга в `bypass_domains.rs` без изменений поведения.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b2e58d9-a35d-40e0-b329-666cd69e8e1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b2e58d9-a35d-40e0-b329-666cd69e8e1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

