### PR TITLE
build: enable fat LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ resolver = "2"
 version = "1.2.0"
 edition = "2021"
 license = "MIT"
+
+[profile.release]
+codegen-units = 1
+lto = "fat"


### PR DESCRIPTION
Closes #25

## Summary
- add a root `[profile.release]` section in `Cargo.toml`
- enable `codegen-units = 1`
- enable `lto = "fat"` for optimized release binaries across the Rust workspace

## Verification
- `cargo build --locked --release --workspace --exclude bibavpn-desktop`

## Notes
- verified in a fresh local toolchain with Rust 1.96.0
- kept the change minimal and scoped to the issue request
