### PR TITLE
Correctness & security fixes: ClientHello parser, rate-limiter, UDP relay, REALITY handshake, desktop proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "subtle",
  "thiserror 2.0.18",
  "tokio",
  "tokio-boring",

--- a/apps/bibavpn-desktop/src-tauri/src/lib.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/lib.rs
@@ -969,6 +969,23 @@ fn open_control_plane_refresh_cmd(
 }
 
 fn open_portal_url(url: &str) -> Result<(), String> {
+    // `url` is built from the control-plane base URL (config / web cabinet), i.e.
+    // partly external input. Refuse anything that isn't a plain http(s) URL before
+    // handing it to a launcher. On Windows `cmd /C start` would otherwise treat
+    // shell metacharacters (& | < > ^ %) in the URL as commands; on macOS/Linux a
+    // leading '-' could be parsed as a flag by `open`/`xdg-open`.
+    if !(url.starts_with("https://") || url.starts_with("http://")) {
+        return Err("Недопустимый URL веб-кабинета.".into());
+    }
+    if url.len() > 2048
+        || url.chars().any(|c| {
+            c.is_control()
+                || c.is_whitespace()
+                || matches!(c, '&' | '|' | '<' | '>' | '^' | '"' | '\'' | '%' | '`')
+        })
+    {
+        return Err("Недопустимый URL веб-кабинета.".into());
+    }
     #[cfg(target_os = "android")]
     {
         use tauri::Manager;

--- a/apps/bibavpn-desktop/src-tauri/src/lib.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/lib.rs
@@ -1180,6 +1180,16 @@ pub fn run() -> anyhow::Result<()> {
                 }
             })
             .setup(move |app| {
+                // If a previous run crashed while connected, the system proxy may
+                // still point at our now-dead local listener, leaving the user
+                // without working internet. Clear any residual BibaVPN proxy at
+                // startup (restore() otherwise only runs on a clean exit).
+                #[cfg(windows)]
+                {
+                    if let Err(e) = crate::proxy_win::disable_if_residual_biba_proxy() {
+                        warn!(target: "bibavpn_desktop", "очистка остаточного прокси при старте: {e}");
+                    }
+                }
                 let tray_cfg = app
                     .state::<AppState>()
                     .inner

--- a/biba/src/parse.rs
+++ b/biba/src/parse.rs
@@ -55,6 +55,11 @@ fn parse_client_hello_handshake(data: &[u8], blunt: bool) -> Result<ClientHelloS
 
     let cs_len = u16::from_be_bytes([ch[o], ch[o + 1]]) as usize;
     o += 2;
+    if cs_len % 2 != 0 {
+        // Must be a whole number of u16 cipher suites; an odd length would read
+        // past the list (into the compression byte, or out of bounds → panic).
+        return Err(Error::InvalidClientHello("odd cipher-suite length"));
+    }
     if ch.len() < o + cs_len + 1 {
         return Err(Error::UnexpectedEof);
     }

--- a/biba/src/randomized.rs
+++ b/biba/src/randomized.rs
@@ -218,6 +218,17 @@ pub fn generate_randomized_spec(id: ClientHelloId) -> Result<ClientHelloSpec> {
 
     exts.shuffle(&mut rng);
 
+    // BoringSSL-style padding pads the whole ClientHello to a target length, so
+    // it must be the final extension. The shuffle above can move it anywhere;
+    // pull any Padding extension back to the end (uTLS keeps it last as well).
+    if let Some(pos) = exts
+        .iter()
+        .position(|e| matches!(e, Extension::Padding { .. }))
+    {
+        let pad = exts.remove(pos);
+        exts.push(pad);
+    }
+
     Ok(ClientHelloSpec {
         cipher_suites: suites,
         compression_methods: vec![COMPRESSION_NONE],

--- a/bibavpn/Cargo.toml
+++ b/bibavpn/Cargo.toml
@@ -24,6 +24,7 @@ blake3 = "1.5"
 bytes = "1"
 chacha20poly1305 = { version = "0.10", features = ["std"] }
 clap = { version = "4.5", features = ["derive"] }
+subtle = "2"
 futures-util = "0.3"
 http = "1"
 httparse = "1"

--- a/bibavpn/src/bin/server.rs
+++ b/bibavpn/src/bin/server.rs
@@ -799,7 +799,17 @@ where
         } => {
             info!("OPEN {host}:{port}");
             let mut pad_st = AdaptivePadState::default();
-            let remote = match TcpStream::connect((host.as_str(), port)).await {
+            // Bound the dial so a blackholed target cannot tie up the session
+            // (and its concurrency permit) until the OS TCP timeout (~minutes).
+            let connect = timeout(mux_connect_timeout, TcpStream::connect((host.as_str(), port)))
+                .await
+                .unwrap_or_else(|_| {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "connect timed out",
+                    ))
+                });
+            let remote = match connect {
                 Ok(remote) => remote,
                 Err(e) => {
                     if supports_open_status {

--- a/bibavpn/src/crypto_layer.rs
+++ b/bibavpn/src/crypto_layer.rs
@@ -9,6 +9,7 @@ use chacha20poly1305::ChaCha20Poly1305;
 use rand::rngs::OsRng;
 use rand::Rng;
 use rand::RngCore;
+use subtle::ConstantTimeEq;
 
 /// First byte of Biba v3 opaque client hello (after WS noise/junk).
 pub const V3_HELLO_TAG: u8 = 0x03;
@@ -253,7 +254,8 @@ pub fn parse_ack(
         bail!("bad v3 ACK length");
     }
     let expected = compute_mac(psk.as_bytes(), domain, client_random, &s);
-    if tag != expected.as_slice() {
+    // Constant-time compare: avoid leaking how many leading bytes matched.
+    if tag.ct_ne(expected.as_slice()).into() {
         bail!("ACK mac mismatch");
     }
     Ok(s)

--- a/bibavpn/src/reality.rs
+++ b/bibavpn/src/reality.rs
@@ -31,6 +31,11 @@ use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
 pub const REALITY_MAGIC: &[u8] = b"REAL1";
 pub const REALITY_VERSION: u8 = 1;
 
+/// Max Ping/Pong frames tolerated during the REALITY handshake before the peer
+/// is rejected. Stops a pre-auth peer from holding the loop open indefinitely or
+/// forcing unbounded Pong replies (amplification).
+const MAX_HANDSHAKE_CONTROL_FRAMES: u32 = 16;
+
 /// REALITY server configuration
 #[derive(Debug, Clone)]
 pub struct RealityServerConfig {
@@ -204,14 +209,25 @@ pub async fn server_handshake_reality<S>(
 where
     S: AsyncRead + AsyncWrite + Unpin + Send,
 {
+    let mut control_frames: u32 = 0;
     loop {
         let msg = match ws.next().await {
             Some(Ok(Message::Binary(b))) => b,
             Some(Ok(Message::Ping(p))) => {
+                control_frames += 1;
+                if control_frames > MAX_HANDSHAKE_CONTROL_FRAMES {
+                    bail!("too many control frames during REALITY handshake");
+                }
                 ws.send(Message::Pong(p)).await.context("REALITY pong")?;
                 continue;
             }
-            Some(Ok(Message::Pong(_))) => continue,
+            Some(Ok(Message::Pong(_))) => {
+                control_frames += 1;
+                if control_frames > MAX_HANDSHAKE_CONTROL_FRAMES {
+                    bail!("too many control frames during REALITY handshake");
+                }
+                continue;
+            }
             Some(Ok(_)) => bail!("expected binary REALITY HELLO"),
             Some(Err(e)) => Err(e).context("websocket recv")?,
             None => bail!("ws closed before REALITY HELLO"),
@@ -319,16 +335,27 @@ where
         .await
         .context("send REALITY client hello")?;
 
+    let mut control_frames: u32 = 0;
     loop {
         let msg = match ws.next().await {
             Some(Ok(Message::Binary(b))) => b,
             Some(Ok(Message::Ping(p))) => {
+                control_frames += 1;
+                if control_frames > MAX_HANDSHAKE_CONTROL_FRAMES {
+                    bail!("too many control frames during REALITY handshake");
+                }
                 ws.send(Message::Pong(p))
                     .await
                     .context("REALITY client pong")?;
                 continue;
             }
-            Some(Ok(Message::Pong(_))) => continue,
+            Some(Ok(Message::Pong(_))) => {
+                control_frames += 1;
+                if control_frames > MAX_HANDSHAKE_CONTROL_FRAMES {
+                    bail!("too many control frames during REALITY handshake");
+                }
+                continue;
+            }
             Some(Ok(_)) => bail!("expected binary server hello"),
             Some(Err(e)) => Err(e).context("websocket recv")?,
             None => bail!("server closed during REALITY handshake"),

--- a/bibavpn/src/server_limits.rs
+++ b/bibavpn/src/server_limits.rs
@@ -34,6 +34,11 @@ struct IpAuthState {
     banned_until: Option<Instant>,
 }
 
+/// Hard cap on tracked source IPs, to bound memory under IP-rotation floods
+/// (e.g. an attacker cycling through a /64). Without this the map only ever
+/// shrank on a *successful* auth, so failed handshakes grew it without bound.
+const MAX_TRACKED_IPS: usize = 100_000;
+
 pub struct AuthRateLimiter {
     cfg: AuthRateLimiterConfig,
     inner: Mutex<HashMap<IpAddr, IpAuthState>>,
@@ -71,12 +76,47 @@ impl AuthRateLimiter {
         Ok(())
     }
 
+    /// Drop entries that no longer carry state: expired (uncleared) bans and
+    /// idle windows. Keeps active bans and in-progress windows. Adjusts
+    /// `bans_active` for any expired ban it reaps.
+    fn prune_locked(&self, g: &mut HashMap<IpAddr, IpAuthState>, now: Instant) {
+        g.retain(|_, st| match st.banned_until {
+            Some(until) if now < until => true,
+            Some(_) => {
+                // Ban expired but was never cleared, so it is still counted.
+                let _ = self.bans_active.fetch_sub(1, Ordering::Relaxed);
+                false
+            }
+            None => now.duration_since(st.window_start) <= self.cfg.window,
+        });
+    }
+
     pub async fn record_failure(self: &Arc<Self>, ip: IpAddr) {
         if !self.cfg.enabled {
             return;
         }
         let mut g = self.inner.lock().await;
         let now = Instant::now();
+        if g.len() >= MAX_TRACKED_IPS && !g.contains_key(&ip) {
+            self.prune_locked(&mut g, now);
+            if g.len() >= MAX_TRACKED_IPS {
+                // Still full of active windows/bans: evict the oldest entry that
+                // is not currently banned, rather than grow past the cap.
+                let victim = g
+                    .iter()
+                    .filter(|(_, s)| s.banned_until.map_or(true, |u| now >= u))
+                    .min_by_key(|(_, s)| s.window_start)
+                    .map(|(k, _)| *k);
+                match victim {
+                    Some(k) => {
+                        g.remove(&k);
+                    }
+                    // Everything tracked is actively banned; the table is already
+                    // doing its job. Skip recording this new IP to stay bounded.
+                    None => return,
+                }
+            }
+        }
         let st = g.entry(ip).or_insert(IpAuthState {
             failures: 0,
             window_start: now,

--- a/bibavpn/src/udp_mux.rs
+++ b/bibavpn/src/udp_mux.rs
@@ -775,7 +775,8 @@ where
                                 UdpSockHolder::Ephemeral(bind_udp_for_family(want_v6).await?)
                             };
                             let sock = holder.sock_mut();
-                            sock.set_broadcast(true).ok();
+                            // Do not enable SO_BROADCAST: it let a client steer
+                            // relayed UDP at broadcast addresses (amplification).
                             if let Err(e) = sock.send_to(&payload, dest).await {
                                 last_err = Some(anyhow::Error::from(e).context("udp send"));
                                 continue;


### PR DESCRIPTION
## Summary

Nine independent fixes from a code review, each in its own commit (correctness + security). No protocol/wire changes — all are backward compatible.

| Commit | Area | Fix | Type |
|---|---|---|---|
| `fix(biba): reject odd cipher-suite length …` | `biba/src/parse.rs` | A malformed ClientHello with an odd cipher-suites length read past the list (into the compression byte, or out of bounds → panic). Reject odd lengths before iterating. | bug |
| `fix(biba): keep TLS padding extension last …` | `biba/src/randomized.rs` | The randomized-spec shuffle could move BoringSSL-style `Padding` out of last position, breaking the padded record length / fingerprint. Move it back to the end (matches uTLS). | bug |
| `security(crypto): constant-time MAC comparison …` | `bibavpn/src/crypto_layer.rs` | `parse_ack` compared the 16-byte handshake MAC with `!=`, leaking via timing how many leading bytes matched. Use `subtle::ConstantTimeEq`. | security |
| `fix(server): bound per-IP auth rate-limiter memory` | `bibavpn/src/server_limits.rs` | The per-IP failure map only shrank on a successful AUTH, so an attacker rotating source IPs (trivial behind an IPv6 /64) grew it without bound. Add a hard cap with pruning of expired bans / idle windows, and oldest-non-banned eviction. | security (DoS) |
| `fix(server): add connect timeout on the TCP tunnel path` | `bibavpn/src/bin/server.rs` | The single-stream `FirstChannel::Tcp` path dialed the target with no timeout; a blackholed target tied up the session and its concurrency permit until the OS TCP timeout. Bound with `mux_connect_timeout`. | bug |
| `fix(udp): stop enabling SO_BROADCAST on relay sockets` | `bibavpn/src/udp_mux.rs` | Every outbound UDP relay socket enabled broadcast unconditionally, letting a client steer relayed datagrams at broadcast addresses (amplification). | security |
| `fix(reality): bound control frames during handshake` | `bibavpn/src/reality.rs` | Both REALITY handshake loops replied to Ping with Pong indefinitely, letting a pre-auth peer hold the loop open / force unbounded Pong replies (amplification). Cap accepted Ping/Pong frames. | bug |
| `security(desktop): validate portal URL before launching` | `apps/bibavpn-desktop/src-tauri/src/lib.rs` | `open_portal_url` passed a control-plane-derived URL to `cmd /C start` on Windows, where cmd.exe interprets shell metacharacters (`& \| < > ^ %`) → command injection. Reject anything that isn't a plain, metacharacter-free http(s) URL. | security |
| `fix(desktop): clear residual system proxy on startup (Windows)` | `apps/bibavpn-desktop/src-tauri/src/lib.rs` | `restore()` only ran on a clean exit, so a crash while connected left the system proxy pointing at the dead local listener (no working internet). Call the existing residual-cleanup once at startup. | bug |

## Verification

- `cargo check` on `biba`, `bibavpn`, `bibavpn-desktop` — clean (built with the VS 2022 Build Tools MSVC linker).
- `cargo test -p biba -p bibavpn` — **115 tests pass, 0 failures** (incl. the rate-limiter and REALITY-handshake suites; no regressions).

## Deliberately out of scope

These are real findings from the same review but are protocol-breaking or change data-path semantics, so they need a coordinated version bump and an end-to-end test rather than a drive-by fix:

- **REALITY DH is decorative** — the X25519 shared secret is discarded (`reality.rs`) and the client's `session_key` is dropped (`local_client.rs`); the channel is keyed off the PSK only. A real fix folds the DH secret into the key schedule (or adds a server confirmation MAC), which changes the `SERVER_HELLO` wire format on both ends.
- **Head-of-line blocking in the mux** — the demux loop `await`s a per-stream bounded `send`, so one slow consumer stalls every stream on the session. `try_send`+RST would break legitimate slow transfers; the proper fix is per-stream flow control (the declared-but-unimplemented `MUX_FLAG_WIN`).
- **TCP half-close / stream-id reuse** in the mux — same reason (data-path behavior change, needs load testing).
- **FFI/JNI panic-unwinding across the boundary** — not built here (needs the Android NDK / iOS toolchain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
