### PR TITLE
fix(client): abort mux session tasks on VPN shutdown (#41)

### DIFF
--- a/bibavpn/src/local_client.rs
+++ b/bibavpn/src/local_client.rs
@@ -1,6 +1,6 @@
 //! Shared SOCKS5 / HTTP CONNECT front-end for desktop binary and Android JNI.
 
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 
 use anyhow::Context;
 use futures_util::{SinkExt, StreamExt};
@@ -11,6 +11,7 @@ use rustls::pki_types::ServerName;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::sync::{mpsc, watch, Mutex, Semaphore};
+use tokio::task::JoinHandle;
 use tokio::time::{timeout, Duration};
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::WebSocketStream;
@@ -82,6 +83,44 @@ fn tcp_mux_writer_gone(e: &anyhow::Error) -> bool {
 
 type TcpMuxSlot = TcpMuxClientSlot;
 
+/// Tracks per-session background tasks; abort on VPN shutdown so mux WSS/ping loops stop.
+#[derive(Clone)]
+struct SessionGuard {
+    shutdown: watch::Receiver<bool>,
+    tasks: Arc<StdMutex<Vec<JoinHandle<()>>>>,
+}
+
+impl SessionGuard {
+    fn new(shutdown: watch::Receiver<bool>) -> Self {
+        Self {
+            shutdown,
+            tasks: Arc::new(StdMutex::new(Vec::new())),
+        }
+    }
+
+    fn shutdown_rx(&self) -> watch::Receiver<bool> {
+        self.shutdown.clone()
+    }
+
+    fn push_task(&self, handle: JoinHandle<()>) {
+        if let Ok(mut g) = self.tasks.lock() {
+            g.push(handle);
+        }
+    }
+
+    fn with_tasks<R>(&self, f: impl FnOnce(&mut Vec<JoinHandle<()>>) -> R) -> R {
+        let mut g = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
+        f(&mut g)
+    }
+
+    async fn abort_all(&self) {
+        let mut handles = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
+        for h in handles.drain(..) {
+            h.abort();
+        }
+    }
+}
+
 async fn tcp_mux_open_stream_with_retry(
     mut local: TcpStream,
     host: String,
@@ -89,10 +128,11 @@ async fn tcp_mux_open_stream_with_retry(
     tcp_uplink_prefix: Vec<u8>,
     cfg: Arc<ClientCfg>,
     tcp_mux_slot: TcpMuxSlot,
+    session: &SessionGuard,
 ) -> anyhow::Result<()> {
     for attempt in 0..TCP_MUX_SLOT_RETRIES {
         if tcp_mux_slot.lock().await.is_none() {
-            connect_tcp_mux_handle(&cfg, &tcp_mux_slot).await?;
+            connect_tcp_mux_handle(&cfg, &tcp_mux_slot, session).await?;
         }
         let h = {
             let slot = tcp_mux_slot.lock().await;
@@ -595,9 +635,13 @@ async fn open_legacy_biba_channel(
     Err(last_err.unwrap_or_else(|| anyhow::anyhow!("tunnel: connect failed")))
 }
 
-async fn ensure_tcp_mux_ready(cfg: &Arc<ClientCfg>, tcp_mux_slot: &TcpMuxSlot) -> anyhow::Result<()> {
+async fn ensure_tcp_mux_ready(
+    cfg: &Arc<ClientCfg>,
+    tcp_mux_slot: &TcpMuxSlot,
+    session: &SessionGuard,
+) -> anyhow::Result<()> {
     if tcp_mux_slot.lock().await.is_none() {
-        connect_tcp_mux_handle(cfg, tcp_mux_slot).await?;
+        connect_tcp_mux_handle(cfg, tcp_mux_slot, session).await?;
     }
     Ok(())
 }
@@ -605,18 +649,21 @@ async fn ensure_tcp_mux_ready(cfg: &Arc<ClientCfg>, tcp_mux_slot: &TcpMuxSlot) -
 async fn connect_tcp_mux_handle(
     cfg: &Arc<ClientCfg>,
     tcp_mux_slot: &TcpMuxSlot,
+    session: &SessionGuard,
 ) -> anyhow::Result<()> {
-    connect_tcp_mux_handle_attempts(cfg, tcp_mux_slot, OUTBOUND_CONNECT_ATTEMPTS).await
+    connect_tcp_mux_handle_attempts(cfg, tcp_mux_slot, OUTBOUND_CONNECT_ATTEMPTS, session).await
 }
 
 async fn connect_tcp_mux_handle_attempts(
     cfg: &Arc<ClientCfg>,
     tcp_mux_slot: &TcpMuxSlot,
     max_attempts: u32,
+    session: &SessionGuard,
 ) -> anyhow::Result<()> {
     // Check if REALITY mode is enabled
     if cfg.reality_target.is_some() {
-        return connect_reality_tcp_mux_handle_attempts(cfg, tcp_mux_slot, max_attempts).await;
+        return connect_reality_tcp_mux_handle_attempts(cfg, tcp_mux_slot, max_attempts, session)
+            .await;
     }
 
     let _connect_serial = tcp_mux_connect_serial().lock().await;
@@ -665,12 +712,16 @@ async fn connect_tcp_mux_handle_attempts(
                     dummy_interval_secs: cfg.dummy_interval_secs,
                     activity: cfg.activity.clone(),
                 };
-                let (sid, h) = tcp_mux::spawn_tcp_mux_client(
-                    ws,
-                    Some(crypto),
-                    mcfg,
-                    tcp_mux_slot.clone(),
-                );
+                let (sid, h) = session.with_tasks(|tasks| {
+                    tcp_mux::spawn_tcp_mux_client(
+                        ws,
+                        Some(crypto),
+                        mcfg,
+                        tcp_mux_slot.clone(),
+                        session.shutdown_rx(),
+                        tasks,
+                    )
+                });
                 sessions.push((sid, h));
                 info!(
                     target: "bibavpn_client",
@@ -705,6 +756,7 @@ async fn connect_reality_tcp_mux_handle_attempts(
     cfg: &Arc<ClientCfg>,
     tcp_mux_slot: &TcpMuxSlot,
     max_attempts: u32,
+    session: &SessionGuard,
 ) -> anyhow::Result<()> {
     use tokio_tungstenite::tungstenite::Message;
 
@@ -758,8 +810,16 @@ async fn connect_reality_tcp_mux_handle_attempts(
                     activity: cfg.activity.clone(),
                 };
 
-                let (sid, h) =
-                    tcp_mux::spawn_tcp_mux_client(ws, None, mcfg, tcp_mux_slot.clone());
+                let (sid, h) = session.with_tasks(|tasks| {
+                    tcp_mux::spawn_tcp_mux_client(
+                        ws,
+                        None,
+                        mcfg,
+                        tcp_mux_slot.clone(),
+                        session.shutdown_rx(),
+                        tasks,
+                    )
+                });
                 sessions.push((sid, h));
                 info!(
                     target: "bibavpn_client",
@@ -915,6 +975,8 @@ pub async fn run_local_client(
         pinned_certs_pem: opts.pinned_certs_pem.clone(),
     });
 
+    let session = SessionGuard::new(shutdown.clone());
+
     if cfg.decoy_gets {
         let ua = cfg
             .ws_user_agent
@@ -972,7 +1034,7 @@ pub async fn run_local_client(
                 "idle decoy: after {} s without tunneled traffic, issue HTTPS GET (mode {:?})",
                 idle_s, cfg.decoy_mode
             );
-            tokio::spawn(async move {
+            session.push_task(tokio::spawn(async move {
                 loop {
                     if *sd.borrow() {
                         break;
@@ -987,7 +1049,7 @@ pub async fn run_local_client(
                         }
                     }
                 }
-            });
+            }));
         }
     }
 
@@ -1001,8 +1063,13 @@ pub async fn run_local_client(
             port = cfg.server_port,
             "opening remote multiplexed WSS"
         );
-        connect_tcp_mux_handle_attempts(&cfg, &tcp_mux_slot, STARTUP_MUX_CONNECT_ATTEMPTS)
-            .await
+        connect_tcp_mux_handle_attempts(
+            &cfg,
+            &tcp_mux_slot,
+            STARTUP_MUX_CONNECT_ATTEMPTS,
+            &session,
+        )
+        .await
             .with_context(|| {
                 if cfg.pinned_certs_pem.is_some() {
                     "remote tunnel connect failed (verify pin_cert_pem matches the server leaf certificate, SNI, and server reachability)"
@@ -1029,7 +1096,8 @@ pub async fn run_local_client(
         let cfg_http = cfg.clone();
         let tcp_mux_http = tcp_mux_slot.clone();
         let mut shutdown_http = shutdown.clone();
-        tokio::spawn(async move {
+        let sess_http = session.clone();
+        session.push_task(tokio::spawn(async move {
             loop {
                 tokio::select! {
                     _ = shutdown_http.changed() => {
@@ -1042,8 +1110,9 @@ pub async fn run_local_client(
                             Ok((sock, peer)) => {
                                 let c = cfg_http.clone();
                                 let tms = tcp_mux_http.clone();
+                                let sess = sess_http.clone();
                                 tokio::spawn(async move {
-                                    if let Err(e) = handle_http_peer(sock, c, tms).await {
+                                    if let Err(e) = handle_http_peer(sock, c, tms, sess).await {
                                         error!("http {peer}: {e:#}");
                                     }
                                 });
@@ -1055,7 +1124,7 @@ pub async fn run_local_client(
                     }
                 }
             }
-        });
+        }));
     }
 
     loop {
@@ -1063,6 +1132,9 @@ pub async fn run_local_client(
             _ = shutdown.changed() => {
                 if *shutdown.borrow() {
                     info!("local client shutdown");
+                    *tcp_mux_slot.lock().await = None;
+                    *udp_mux_slot.lock().await = None;
+                    session.abort_all().await;
                     return Ok(());
                 }
             }
@@ -1071,8 +1143,9 @@ pub async fn run_local_client(
                 let c = cfg.clone();
                 let ums = udp_mux_slot.clone();
                 let tms = tcp_mux_slot.clone();
+                let sess = session.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = handle_socks_peer(sock, c, ums, tms).await {
+                    if let Err(e) = handle_socks_peer(sock, c, ums, tms, sess).await {
                         if socks5::is_benign_handshake_abort(&e) {
                             debug!("socks {peer}: client closed before SOCKS5 handshake");
                         } else {
@@ -1107,16 +1180,17 @@ async fn handle_socks_peer(
     cfg: Arc<ClientCfg>,
     udp_mux_slot: Arc<Mutex<Option<UdpMuxHandle>>>,
     tcp_mux_slot: TcpMuxSlot,
+    session: SessionGuard,
 ) -> anyhow::Result<()> {
     match socks5::socks5_read_command(&mut local, cfg.socks_auth.as_ref()).await? {
         SocksCommand::Connect { host, port } => {
             if cfg.use_tcp_mux {
-                if let Err(e) = ensure_tcp_mux_ready(&cfg, &tcp_mux_slot).await {
+                if let Err(e) = ensure_tcp_mux_ready(&cfg, &tcp_mux_slot, &session).await {
                     let _ = socks5::socks5_reply_err(&mut local).await;
                     return Err(e);
                 }
                 socks5::socks5_reply_ok(&mut local).await?;
-                tcp_mux_open_stream_with_retry(local, host, port, Vec::new(), cfg, tcp_mux_slot)
+                tcp_mux_open_stream_with_retry(local, host, port, Vec::new(), cfg, tcp_mux_slot, &session)
                     .await
             } else {
                 let (ws, crypto, prefetched_ws_messages) =
@@ -1156,7 +1230,7 @@ async fn handle_socks_peer(
                 .context("bind udp relay")?;
             let relay_port = udp.local_addr()?.port();
             socks5::socks5_reply_udp_associate(&mut local, relay_port).await?;
-            run_socks_udp_assoc(local, udp, cfg, udp_mux_slot).await
+            run_socks_udp_assoc(local, udp, cfg, udp_mux_slot, session).await
         }
     }
 }
@@ -1167,6 +1241,7 @@ async fn run_socks_udp_assoc(
     udp: UdpSocket,
     cfg: Arc<ClientCfg>,
     mux_slot: Arc<Mutex<Option<UdpMuxHandle>>>,
+    session: SessionGuard,
 ) -> anyhow::Result<()> {
     let (close_tx, mut close_rx) = mpsc::unbounded_channel();
     tokio::spawn(async move {
@@ -1184,7 +1259,9 @@ async fn run_socks_udp_assoc(
     let handle = {
         let mut g = mux_slot.lock().await;
         if g.is_none() {
-            *g = Some(spawn_udp_mux_driver(cfg.udp_mux_config()));
+            *g = Some(session.with_tasks(|tasks| {
+                spawn_udp_mux_driver(cfg.udp_mux_config(), session.shutdown_rx(), tasks)
+            }));
         }
         g.as_ref().expect("udp mux just set").clone()
     };
@@ -1268,6 +1345,7 @@ async fn handle_http_peer(
     mut local: TcpStream,
     cfg: Arc<ClientCfg>,
     tcp_mux_slot: TcpMuxSlot,
+    session: SessionGuard,
 ) -> anyhow::Result<()> {
     if http_connect::try_serve_health_check(&mut local).await? {
         return Ok(());
@@ -1279,7 +1357,7 @@ async fn handle_http_peer(
             client_prefetch,
         }) => {
             if cfg.use_tcp_mux {
-                if let Err(e) = ensure_tcp_mux_ready(&cfg, &tcp_mux_slot).await {
+                if let Err(e) = ensure_tcp_mux_ready(&cfg, &tcp_mux_slot, &session).await {
                     let _ =
                         http_connect::reply_connect_error(&mut local, 502, "Bad Gateway").await;
                     return Err(e);
@@ -1292,6 +1370,7 @@ async fn handle_http_peer(
                     client_prefetch,
                     cfg,
                     tcp_mux_slot,
+                    &session,
                 )
                 .await
             } else {
@@ -1334,12 +1413,12 @@ async fn handle_http_peer(
             to_origin,
         }) => {
             if cfg.use_tcp_mux {
-                if let Err(e) = ensure_tcp_mux_ready(&cfg, &tcp_mux_slot).await {
+                if let Err(e) = ensure_tcp_mux_ready(&cfg, &tcp_mux_slot, &session).await {
                     let _ =
                         http_connect::reply_connect_error(&mut local, 502, "Bad Gateway").await;
                     return Err(e);
                 }
-                tcp_mux_open_stream_with_retry(local, host, port, to_origin, cfg, tcp_mux_slot)
+                tcp_mux_open_stream_with_retry(local, host, port, to_origin, cfg, tcp_mux_slot, &session)
                     .await
             } else {
                 tunnel_to_biba(local, host, port, cfg, to_origin).await
@@ -1461,5 +1540,33 @@ mod parse_tests {
     #[test]
     fn parse_ws_header_requires_colon() {
         assert!(parse_ws_header("BadHeader").is_err());
+    }
+}
+
+#[cfg(test)]
+mod session_shutdown_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn session_guard_aborts_tracked_tasks() {
+        let (tx, rx) = watch::channel(false);
+        let session = SessionGuard::new(rx);
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_task = hits.clone();
+        session.push_task(tokio::spawn(async move {
+            loop {
+                hits_task.fetch_add(1, Ordering::Relaxed);
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }));
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(hits.load(Ordering::Relaxed) > 0);
+        let _ = tx.send(true);
+        session.abort_all().await;
+        let after = hits.load(Ordering::Relaxed);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(hits.load(Ordering::Relaxed), after);
     }
 }

--- a/bibavpn/src/tcp_mux.rs
+++ b/bibavpn/src/tcp_mux.rs
@@ -15,7 +15,8 @@ use rand::Rng;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, ReadBuf};
 use tokio::net::tcp::OwnedReadHalf;
 use tokio::net::TcpStream;
-use tokio::sync::{mpsc, Mutex, Semaphore};
+use tokio::sync::{mpsc, watch, Mutex, Semaphore};
+use tokio::task::JoinHandle;
 use tokio::time::{sleep, Duration};
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::WebSocketStream;
@@ -777,6 +778,8 @@ pub fn spawn_tcp_mux_client<S>(
     crypto: Option<SharedCrypto>,
     mut cfg: MuxClientConfig,
     tcp_mux_slot: TcpMuxClientSlot,
+    mut shutdown: watch::Receiver<bool>,
+    tasks: &mut Vec<JoinHandle<()>>,
 ) -> (u64, TcpMuxClientHandle)
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
@@ -791,7 +794,10 @@ where
         let tx_d = tx.clone();
         let cfg_d = cfg.clone();
         let crypto_d = crypto.clone();
-        tokio::spawn(mux_client_dummy_task(tx_d, cfg_d, crypto_d));
+        let mut sd_d = shutdown.clone();
+        tasks.push(tokio::spawn(async move {
+            mux_client_dummy_task(tx_d, cfg_d, crypto_d, sd_d).await;
+        }));
     }
     let tx_reader = tx.clone();
     let down: Arc<Mutex<HashMap<u32, mpsc::Sender<Vec<u8>>>>> =
@@ -802,7 +808,8 @@ where
     let cfg_w = cfg.clone();
     let cfg_r = cfg.clone();
 
-    tokio::spawn(async move {
+    let mut sd_w = shutdown.clone();
+    tasks.push(tokio::spawn(async move {
         let mut ping_sleep: Option<Pin<Box<tokio::time::Sleep>>> = if cfg_w.ws_ping_secs > 0 {
             Some(Box::pin(sleep(ws_ping_period_duration(
                 cfg_w.ws_ping_secs,
@@ -817,10 +824,19 @@ where
         let send_j = cfg_w.send_jitter();
 
         loop {
+            if *sd_w.borrow() {
+                break;
+            }
             let cmd = match ping_sleep.as_mut() {
                 Some(sleep_pin) => {
                     tokio::select! {
                         cmd = rx.recv() => cmd,
+                        _ = sd_w.changed() => {
+                            if *sd_w.borrow() {
+                                break;
+                            }
+                            continue;
+                        }
                         _ = sleep_pin.as_mut() => {
                             if ws_sink.send(Message::Ping(Bytes::new())).await.is_err() {
                                 break;
@@ -833,7 +849,17 @@ where
                         }
                     }
                 }
-                None => rx.recv().await,
+                None => {
+                    tokio::select! {
+                        cmd = rx.recv() => cmd,
+                        _ = sd_w.changed() => {
+                            if *sd_w.borrow() {
+                                break;
+                            }
+                            continue;
+                        }
+                    }
+                }
             };
             let Some(first) = cmd else { break };
             let mut stop = false;
@@ -920,11 +946,15 @@ where
             }
         }
         remove_mux_session(&slot_w, session_id).await;
-    });
+    }));
 
-    tokio::spawn(mux_client_reader_loop(
-        ws_rx, crypto_r, cfg_r, down_r, tx_reader, session_id, slot_r,
-    ));
+    let mut sd_r = shutdown;
+    tasks.push(tokio::spawn(async move {
+        mux_client_reader_loop(
+            ws_rx, crypto_r, cfg_r, down_r, tx_reader, session_id, slot_r, sd_r,
+        )
+        .await;
+    }));
 
     let handle = TcpMuxClientHandle {
         tx,
@@ -943,13 +973,29 @@ async fn mux_client_reader_loop<S>(
     out_tx: mpsc::Sender<MuxWriteCmd>,
     session_id: u64,
     tcp_mux_slot: TcpMuxClientSlot,
+    mut shutdown: watch::Receiver<bool>,
 ) where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
     use crate::log_ratelimit::LogEvery;
     static DECODE_WARN: LogEvery = LogEvery::new(8, 64);
     let mut decode_failures: u32 = 0;
-    while let Some(m) = ws_rx.next().await {
+    loop {
+        if *shutdown.borrow() {
+            break;
+        }
+        let m = tokio::select! {
+            m = ws_rx.next() => m,
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() {
+                    break;
+                }
+                continue;
+            }
+        };
+        let Some(m) = m else {
+            break;
+        };
         let Ok(m) = m else { break };
         match m {
             Message::Binary(b) => {
@@ -1145,9 +1191,13 @@ async fn mux_client_dummy_task(
     tx: mpsc::Sender<MuxWriteCmd>,
     cfg: MuxClientConfig,
     crypto: Option<SharedCrypto>,
+    mut shutdown: watch::Receiver<bool>,
 ) {
     let mut wire = Vec::with_capacity(cfg.max_ws_binary.min(256 * 1024));
     loop {
+        if *shutdown.borrow() {
+            break;
+        }
         let lo = cfg
             .dummy_interval_secs
             .saturating_mul(1)
@@ -1159,7 +1209,15 @@ async fn mux_client_dummy_task(
             .saturating_div(2)
             .max(lo);
         let secs = rand::thread_rng().gen_range(lo..=hi);
-        sleep(Duration::from_secs(secs)).await;
+        tokio::select! {
+            _ = sleep(Duration::from_secs(secs)) => {}
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() {
+                    break;
+                }
+                continue;
+            }
+        }
         wire.clear();
         if write_padded_frame_with_mode(&mut wire, &[], cfg.max_pad, cfg.pad_mode).is_err() {
             continue;

--- a/bibavpn/src/udp_mux.rs
+++ b/bibavpn/src/udp_mux.rs
@@ -13,7 +13,8 @@ use rand::Rng;
 use rand::RngCore;
 use rustls::pki_types::ServerName;
 use tokio::net::UdpSocket;
-use tokio::sync::{mpsc, Mutex, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{mpsc, watch, Mutex, OwnedSemaphorePermit, Semaphore};
+use tokio::task::JoinHandle;
 use tokio::time::{timeout, Duration};
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::WebSocketStream;
@@ -259,24 +260,35 @@ impl UdpMuxHandle {
 }
 
 /// Start background driver; returns handle for submitting UDP requests.
-pub fn spawn_udp_mux_driver(cfg: UdpMuxConfig) -> UdpMuxHandle {
+pub fn spawn_udp_mux_driver(
+    cfg: UdpMuxConfig,
+    mut shutdown: watch::Receiver<bool>,
+    tasks: &mut Vec<JoinHandle<()>>,
+) -> UdpMuxHandle {
     let (tx, rx) = mpsc::channel(UDP_MUX_CMD_QUEUE_CAP);
-    tokio::spawn(async move {
-        if let Err(e) = run_udp_mux_driver_forever(cfg, rx).await {
+    tasks.push(tokio::spawn(async move {
+        if let Err(e) = run_udp_mux_driver_forever(cfg, rx, shutdown).await {
             error!("udp mux client: {e:#}");
         }
-    });
+    }));
     UdpMuxHandle { tx }
 }
 
 async fn run_udp_mux_driver_forever(
     cfg: UdpMuxConfig,
     mut cmd_rx: mpsc::Receiver<ClientUdpCmd>,
+    mut shutdown: watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     loop {
-        let (ws, crypto) = connect_udp_mux_ws_resilient(&cfg).await?;
-        let shutdown = run_udp_mux_one_session(ws, crypto, &cfg, &mut cmd_rx).await?;
-        if shutdown {
+        if *shutdown.borrow() {
+            return Ok(());
+        }
+        let (ws, crypto) = connect_udp_mux_ws_resilient(&cfg, &mut shutdown).await?;
+        let stop = run_udp_mux_one_session(ws, crypto, &cfg, &mut cmd_rx).await?;
+        if stop {
+            return Ok(());
+        }
+        if *shutdown.borrow() {
             return Ok(());
         }
     }
@@ -284,17 +296,28 @@ async fn run_udp_mux_driver_forever(
 
 async fn connect_udp_mux_ws_resilient(
     cfg: &UdpMuxConfig,
+    shutdown: &mut watch::Receiver<bool>,
 ) -> anyhow::Result<(
     WebSocketStream<tokio_rustls::client::TlsStream<tokio::net::TcpStream>>,
     SharedCrypto,
 )> {
     let mut streak = 0u32;
     loop {
+        if *shutdown.borrow() {
+            anyhow::bail!("udp mux: shutdown");
+        }
         match connect_udp_mux_ws(cfg).await {
             Ok(x) => return Ok(x),
             Err(e) => {
                 warn!("udp mux connect failed (streak {streak}): {e:#}");
-                sleep_outbound_backoff(streak.min(10)).await;
+                tokio::select! {
+                    _ = shutdown.changed() => {
+                        if *shutdown.borrow() {
+                            anyhow::bail!("udp mux: shutdown");
+                        }
+                    }
+                    _ = sleep_outbound_backoff(streak.min(10)) => {}
+                }
                 streak = streak.saturating_add(1);
             }
         }


### PR DESCRIPTION
## Summary
- Add SessionGuard to track and abort tcp-mux / udp-mux background tasks on shutdown
- Wire shutdown into mux writer, reader, and dummy loops
- Stop UDP-mux driver reconnect loop when the client shuts down
- Add unit test asserting session tasks terminate on abort

## Test plan
- [x] cargo test -p bibavpn session_shutdown
- [x] cargo test -p bibavpn --test tunnel_integration
- [ ] Manual: Disconnect — process network drops to ~0 within ~1 s

Fixes #41