### PR TITLE
feat(server): expose Prometheus metrics endpoint (#32)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,7 @@ Full layout for `**apps/`** (desktop, Android, JNI crate, scripts): **[apps/AGEN
 | `bibavpn/src/protocol.rs`                           | Proto-3 sealed opcodes, `UDP_MUX_OPEN`, `UDP_REQ`/`UDP_REP` (`0x05`/`0x06`), ATYP helpers                            |
 | `bibavpn/src/tls_util.rs`, `frame.rs`, `stealth.rs` | Cipher/ALPN + `TlsStack` + record-fragment notes (`tls_util.rs`); `PadMode`; WS upgrade (UA / Sec-CH / `Accept-Language`) |
 | `bibavpn/src/server_limits.rs`                      | `AuthRateLimiter`, `PreAuthBudget`, `ServerStats` / `SessionGuard`                                                 |
+| `bibavpn/src/server_metrics.rs`                     | Prometheus text render + optional HTTP `/metrics` and `/healthz` on `--metrics-listen`; optional `--metrics-password` Basic Auth |
 | `bibavpn/src/transport_capabilities.rs`             | `log_server_listen_caps` / `log_client_transport_caps`; effective desync helpers                                    |
 | `bibavpn/src/logging.rs`                           | Tracing init (`LogConfig`, idempotent second init); `bibavpn/src/log_ratelimit.rs` — hot-path log cadence          |
 | `bibavpn/src/desync.rs`                            | TCP post-connect hints, TLS fragment notes, decoy RTT jitter; **re-export** `effective_desync_mode`, `DesyncApplied` |

--- a/bibavpn/src/bin/server.rs
+++ b/bibavpn/src/bin/server.rs
@@ -11,6 +11,7 @@ use bibavpn::logging::{self, LogConfig, LogFormat};
 use bibavpn::server_limits::{
     AuthRateLimiter, AuthRateLimiterConfig, PreAuthBudget, ServerStats,
 };
+use bibavpn::server_metrics::{spawn_metrics_listener, MetricsAuth};
 use bibavpn::transport_capabilities::log_server_listen_caps;
 use bibavpn::udp_mux::UdpSocketPool;
 use bibavpn::invite_uri::{encode_invite_v1, InviteV1};
@@ -47,6 +48,7 @@ struct ServerConnParams {
     peer: SocketAddr,
     session_id: u64,
     auth: Arc<AuthRateLimiter>,
+    stats: Arc<ServerStats>,
     pre_auth: PreAuthBudget,
     handshake_timeout: Duration,
     mux_connect_timeout: Duration,
@@ -230,6 +232,18 @@ struct Args {
     /// Emit periodic stats every N seconds (0 = off).
     #[arg(long, default_value_t = 0)]
     stats_interval_secs: u64,
+
+    /// Optional Prometheus listener (`host:port`). Serves `GET /metrics` and `GET /healthz`. Off by default; bind loopback in production.
+    #[arg(long)]
+    metrics_listen: Option<String>,
+
+    /// HTTP Basic Auth password for the metrics listener (user defaults to `metrics`). Requires `--metrics-listen`.
+    #[arg(long, requires = "metrics_listen")]
+    metrics_password: Option<String>,
+
+    /// HTTP Basic Auth username for the metrics listener (default `metrics`).
+    #[arg(long, default_value = "metrics", requires = "metrics_password")]
+    metrics_user: String,
 
     /// REALITY mode: target to steal TLS from (e.g., vk.com:443)
     #[arg(long)]
@@ -571,6 +585,19 @@ async fn main() -> anyhow::Result<()> {
         args.udp_socket_pool_size,
     );
 
+    if let Some(ref metrics_listen) = args.metrics_listen {
+        let metrics_auth = match args.metrics_password.as_deref() {
+            Some(pw) if !pw.is_empty() => MetricsAuth::basic(args.metrics_user.trim(), pw),
+            _ => MetricsAuth::disabled(),
+        };
+        spawn_metrics_listener(
+            metrics_listen.clone(),
+            Arc::clone(&stats),
+            Arc::clone(&auth),
+            metrics_auth,
+        );
+    }
+
     if args.stats_interval_secs > 0 {
         let stats_c = Arc::clone(&stats);
         let auth_c = Arc::clone(&auth);
@@ -628,6 +655,7 @@ async fn main() -> anyhow::Result<()> {
                         Ok(Ok(p)) => Some(p),
                         Ok(Err(_)) => return,
                         Err(_) => {
+                            stats.inc_sessions_rejected_busy();
                             debug!(
                                 target: "bibavpn_server",
                                 %peer,
@@ -641,6 +669,7 @@ async fn main() -> anyhow::Result<()> {
             };
 
             if let Err(e) = auth.check_allowed(peer.ip()).await {
+                stats.inc_auth_rejected_banned();
                 debug!(
                     target: "bibavpn_security",
                     %peer,
@@ -657,6 +686,7 @@ async fn main() -> anyhow::Result<()> {
                 peer,
                 session_id,
                 auth,
+                stats: Arc::clone(&stats),
                 pre_auth,
                 handshake_timeout,
                 mux_connect_timeout,
@@ -691,6 +721,7 @@ async fn main() -> anyhow::Result<()> {
             )
             .await
             {
+                stats.inc_session_error();
                 error!(
                     target: "bibavpn_server",
                     %peer,
@@ -733,6 +764,7 @@ async fn server_handshake_v3_after_first_hello<S>(
     decoy_max: u8,
     proto_domain: &str,
     auth: &Arc<AuthRateLimiter>,
+    stats: &Arc<ServerStats>,
     peer_ip: std::net::IpAddr,
     pre_auth: &PreAuthBudget,
     handshake_timeout: Duration,
@@ -754,12 +786,13 @@ where
     ));
     let auth_c = Arc::clone(auth);
     let wait = async {
-        server_wait_v3_auth(ws, &crypto, token, &auth_c, peer_ip, pre_auth).await
+        server_wait_v3_auth(ws, &crypto, token, &auth_c, stats, peer_ip, pre_auth).await
     };
     match timeout(handshake_timeout, wait).await {
         Ok(Ok(())) => {}
         Ok(Err(e)) => return Err(e),
         Err(_) => {
+            stats.inc_handshake_timeout();
             auth.record_failure(peer_ip).await;
             anyhow::bail!("handshake timeout waiting for v3 AUTH (REALITY path)");
         }
@@ -1032,6 +1065,7 @@ async fn handle_one(
                 decoy_max,
                 domain_trim,
                 auth,
+                &params.stats,
                 peer_ip,
                 pre_auth,
                 handshake_timeout,
@@ -1080,6 +1114,7 @@ async fn handle_one(
         decoy_max,
         domain_trim,
         auth,
+        &params.stats,
         peer_ip,
         pre_auth,
         handshake_timeout,
@@ -1177,6 +1212,7 @@ async fn server_handshake_v3<S>(
     decoy_max: u8,
     proto_domain: &str,
     auth: &Arc<AuthRateLimiter>,
+    stats: &Arc<ServerStats>,
     peer_ip: std::net::IpAddr,
     pre_auth: &PreAuthBudget,
     handshake_timeout: Duration,
@@ -1226,7 +1262,8 @@ where
                         decoy_max,
                     ));
                     let auth_c = Arc::clone(&auth_f);
-                    server_wait_v3_auth(ws, &crypto, token, &auth_c, peer, pre_auth).await?;
+                    server_wait_v3_auth(ws, &crypto, token, &auth_c, stats, peer, pre_auth)
+                        .await?;
                     return Ok(crypto);
                 }
                 Message::Ping(p) => {
@@ -1242,6 +1279,7 @@ where
         Ok(Ok(crypto)) => Ok(crypto),
         Ok(Err(e)) => Err(e),
         Err(_) => {
+            stats.inc_handshake_timeout();
             auth_f.record_failure(peer).await;
             anyhow::bail!("handshake timeout");
         }
@@ -1253,6 +1291,7 @@ async fn server_wait_v3_auth<S>(
     crypto: &SharedCrypto,
     expected_token: &str,
     auth: &Arc<AuthRateLimiter>,
+    stats: &Arc<ServerStats>,
     peer_ip: std::net::IpAddr,
     pre_auth: &PreAuthBudget,
 ) -> anyhow::Result<()>
@@ -1295,6 +1334,7 @@ where
                     anyhow::bail!("v3 auth token mismatch");
                 }
                 auth.record_success(peer_ip).await;
+                stats.inc_handshake_success();
                 return Ok(());
             }
             Message::Ping(p) => {

--- a/bibavpn/src/lib.rs
+++ b/bibavpn/src/lib.rs
@@ -31,6 +31,7 @@ pub mod reality;
 pub mod log_ratelimit;
 pub mod logging;
 pub mod server_limits;
+pub mod server_metrics;
 pub mod transport_capabilities;
 pub mod udp_mux;
 pub mod ws_auth;

--- a/bibavpn/src/server_limits.rs
+++ b/bibavpn/src/server_limits.rs
@@ -43,6 +43,8 @@ pub struct AuthRateLimiter {
     cfg: AuthRateLimiterConfig,
     inner: Mutex<HashMap<IpAddr, IpAuthState>>,
     pub bans_active: AtomicU64,
+    pub auth_failures_total: AtomicU64,
+    pub auth_bans_issued_total: AtomicU64,
 }
 
 impl AuthRateLimiter {
@@ -51,6 +53,8 @@ impl AuthRateLimiter {
             cfg,
             inner: Mutex::new(HashMap::new()),
             bans_active: AtomicU64::new(0),
+            auth_failures_total: AtomicU64::new(0),
+            auth_bans_issued_total: AtomicU64::new(0),
         })
     }
 
@@ -134,11 +138,13 @@ impl AuthRateLimiter {
             st.window_start = now;
         }
         st.failures = st.failures.saturating_add(1);
+        self.auth_failures_total.fetch_add(1, Ordering::Relaxed);
         if st.failures >= self.cfg.max_failures {
             st.banned_until = Some(now + self.cfg.ban);
             st.failures = 0;
             st.window_start = now;
             self.bans_active.fetch_add(1, Ordering::Relaxed);
+            self.auth_bans_issued_total.fetch_add(1, Ordering::Relaxed);
         }
     }
 
@@ -205,12 +211,24 @@ impl PreAuthBudgetTracker {
 /// Counts live TLS/WSS sessions (increment when `handle_one` starts after permit, decrement on return).
 pub struct ServerStats {
     pub active_sessions: AtomicU64,
+    pub handshake_timeouts_total: AtomicU64,
+    pub auth_rejected_banned_total: AtomicU64,
+    pub sessions_rejected_busy_total: AtomicU64,
+    pub handshakes_success_total: AtomicU64,
+    pub session_errors_total: AtomicU64,
+    pub started_at: Instant,
 }
 
 impl ServerStats {
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
             active_sessions: AtomicU64::new(0),
+            handshake_timeouts_total: AtomicU64::new(0),
+            auth_rejected_banned_total: AtomicU64::new(0),
+            sessions_rejected_busy_total: AtomicU64::new(0),
+            handshakes_success_total: AtomicU64::new(0),
+            session_errors_total: AtomicU64::new(0),
+            started_at: Instant::now(),
         })
     }
 
@@ -223,6 +241,26 @@ impl ServerStats {
 
     pub fn active_sessions(&self) -> u64 {
         self.active_sessions.load(Ordering::Relaxed)
+    }
+
+    pub fn inc_handshake_timeout(&self) {
+        self.handshake_timeouts_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_auth_rejected_banned(&self) {
+        self.auth_rejected_banned_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_sessions_rejected_busy(&self) {
+        self.sessions_rejected_busy_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_handshake_success(&self) {
+        self.handshakes_success_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_session_error(&self) {
+        self.session_errors_total.fetch_add(1, Ordering::Relaxed);
     }
 }
 

--- a/bibavpn/src/server_metrics.rs
+++ b/bibavpn/src/server_metrics.rs
@@ -1,0 +1,391 @@
+//! Prometheus text exposition and optional HTTP listener for `bibavpn-server`.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::Engine;
+use subtle::ConstantTimeEq;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tracing::{debug, info, warn};
+
+use crate::server_limits::{AuthRateLimiter, ServerStats};
+
+/// Optional HTTP Basic Auth for the metrics listener.
+#[derive(Clone)]
+pub struct MetricsAuth {
+    /// Full `Authorization` header value bytes (`Basic …`), or `None` if auth is disabled.
+    expected_authorization: Option<Vec<u8>>,
+}
+
+impl MetricsAuth {
+    pub fn disabled() -> Self {
+        Self {
+            expected_authorization: None,
+        }
+    }
+
+    pub fn basic(user: &str, password: &str) -> Self {
+        let cred = format!("{user}:{password}");
+        let encoded = base64::engine::general_purpose::STANDARD.encode(cred.as_bytes());
+        Self {
+            expected_authorization: Some(format!("Basic {encoded}").into_bytes()),
+        }
+    }
+
+    pub fn is_required(&self) -> bool {
+        self.expected_authorization.is_some()
+    }
+
+    fn authorize(&self, headers: &[(&str, &str)]) -> bool {
+        let Some(expected) = self.expected_authorization.as_ref() else {
+            return true;
+        };
+        let Some(got) = headers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("authorization"))
+            .map(|(_, v)| v.as_bytes())
+        else {
+            return false;
+        };
+        got.len() == expected.len() && got.ct_eq(expected).into()
+    }
+}
+
+fn parse_http_headers(req: &str) -> Vec<(&str, &str)> {
+    let mut out = Vec::new();
+    for line in req.lines().skip(1) {
+        if line.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            out.push((name.trim(), value.trim()));
+        }
+    }
+    out
+}
+
+/// Render current counters/gauges in Prometheus text format 0.0.4.
+pub fn render_prometheus(stats: &ServerStats, auth: &AuthRateLimiter) -> String {
+    let process_start = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64() - stats.started_at.elapsed().as_secs_f64())
+        .unwrap_or(0.0);
+
+    format!(
+        "\
+# HELP bibavpn_active_sessions Current TLS/WSS sessions being handled.
+# TYPE bibavpn_active_sessions gauge
+bibavpn_active_sessions {active_sessions}
+# HELP bibavpn_auth_bans_active Source IPs currently under temporary auth ban.
+# TYPE bibavpn_auth_bans_active gauge
+bibavpn_auth_bans_active {auth_bans_active}
+# HELP bibavpn_auth_failures_total v3 AUTH failures (token mismatch, junk budget, decrypt errors).
+# TYPE bibavpn_auth_failures_total counter
+bibavpn_auth_failures_total {auth_failures_total}
+# HELP bibavpn_auth_bans_issued_total Temporary auth bans issued since process start.
+# TYPE bibavpn_auth_bans_issued_total counter
+bibavpn_auth_bans_issued_total {auth_bans_issued_total}
+# HELP bibavpn_handshake_timeouts_total Handshakes that exceeded the AUTH wait timeout.
+# TYPE bibavpn_handshake_timeouts_total counter
+bibavpn_handshake_timeouts_total {handshake_timeouts_total}
+# HELP bibavpn_auth_rejected_banned_total Connections rejected because the source IP is banned.
+# TYPE bibavpn_auth_rejected_banned_total counter
+bibavpn_auth_rejected_banned_total {auth_rejected_banned_total}
+# HELP bibavpn_sessions_rejected_busy_total Connections dropped waiting for the concurrent session semaphore.
+# TYPE bibavpn_sessions_rejected_busy_total counter
+bibavpn_sessions_rejected_busy_total {sessions_rejected_busy_total}
+# HELP bibavpn_handshakes_success_total Successful v3 AUTH completions.
+# TYPE bibavpn_handshakes_success_total counter
+bibavpn_handshakes_success_total {handshakes_success_total}
+# HELP bibavpn_session_errors_total Accepted sessions that ended with an error after TLS accept.
+# TYPE bibavpn_session_errors_total counter
+bibavpn_session_errors_total {session_errors_total}
+# HELP bibavpn_process_start_time_seconds Start time of the process since the Unix epoch.
+# TYPE bibavpn_process_start_time_seconds gauge
+bibavpn_process_start_time_seconds {process_start}
+",
+        active_sessions = stats.active_sessions.load(std::sync::atomic::Ordering::Relaxed),
+        auth_bans_active = auth.bans_active.load(std::sync::atomic::Ordering::Relaxed),
+        auth_failures_total = auth
+            .auth_failures_total
+            .load(std::sync::atomic::Ordering::Relaxed),
+        auth_bans_issued_total = auth
+            .auth_bans_issued_total
+            .load(std::sync::atomic::Ordering::Relaxed),
+        handshake_timeouts_total = stats
+            .handshake_timeouts_total
+            .load(std::sync::atomic::Ordering::Relaxed),
+        auth_rejected_banned_total = stats
+            .auth_rejected_banned_total
+            .load(std::sync::atomic::Ordering::Relaxed),
+        sessions_rejected_busy_total = stats
+            .sessions_rejected_busy_total
+            .load(std::sync::atomic::Ordering::Relaxed),
+        handshakes_success_total = stats
+            .handshakes_success_total
+            .load(std::sync::atomic::Ordering::Relaxed),
+        session_errors_total = stats
+            .session_errors_total
+            .load(std::sync::atomic::Ordering::Relaxed),
+        process_start = process_start,
+    )
+}
+
+/// Spawn a background HTTP listener serving `GET /metrics` and `GET /healthz`.
+pub fn spawn_metrics_listener(
+    listen: String,
+    stats: Arc<ServerStats>,
+    auth: Arc<AuthRateLimiter>,
+    metrics_auth: MetricsAuth,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let listener = match TcpListener::bind(&listen).await {
+            Ok(l) => l,
+            Err(e) => {
+                warn!(
+                    target: "bibavpn_server",
+                    %listen,
+                    "metrics listener bind failed: {e:#}"
+                );
+                return;
+            }
+        };
+        if metrics_auth.is_required() {
+            info!(
+                target: "bibavpn_server",
+                %listen,
+                "Prometheus metrics listening with HTTP Basic Auth (GET /metrics, GET /healthz)"
+            );
+        } else {
+            info!(
+                target: "bibavpn_server",
+                %listen,
+                "Prometheus metrics listening (GET /metrics, GET /healthz; no auth — use --metrics-password in production)"
+            );
+        }
+        loop {
+            let Ok((stream, peer)) = listener.accept().await else {
+                continue;
+            };
+            let stats = Arc::clone(&stats);
+            let auth = Arc::clone(&auth);
+            let metrics_auth = metrics_auth.clone();
+            tokio::spawn(async move {
+                if let Err(e) = serve_one_http(stream, &stats, &auth, &metrics_auth).await {
+                    debug!(
+                        target: "bibavpn_server",
+                        %peer,
+                        "metrics HTTP: {e:#}"
+                    );
+                }
+            });
+        }
+    })
+}
+
+async fn serve_one_http(
+    mut stream: TcpStream,
+    stats: &ServerStats,
+    auth: &AuthRateLimiter,
+    metrics_auth: &MetricsAuth,
+) -> anyhow::Result<()> {
+    let mut buf = [0u8; 2048];
+    let n = stream.read(&mut buf).await?;
+    if n == 0 {
+        return Ok(());
+    }
+    let req = std::str::from_utf8(&buf[..n]).unwrap_or("");
+    let headers = parse_http_headers(req);
+    let mut lines = req.lines();
+    let request_line = lines.next().unwrap_or("");
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let path = parts.next().unwrap_or("");
+
+    if method != "GET" {
+        write_http_response(&mut stream, 405, "text/plain; charset=utf-8", b"method not allowed", &[])
+            .await?;
+        return Ok(());
+    }
+
+    if !metrics_auth.authorize(&headers) {
+        write_http_response(
+            &mut stream,
+            401,
+            "text/plain; charset=utf-8",
+            b"unauthorized",
+            &[("WWW-Authenticate", r#"Basic realm="bibavpn-metrics""#)],
+        )
+        .await?;
+        return Ok(());
+    }
+
+    match path {
+        "/metrics" => {
+            let body = render_prometheus(stats, auth);
+            write_http_response(
+                &mut stream,
+                200,
+                "text/plain; version=0.0.4; charset=utf-8",
+                body.as_bytes(),
+                &[],
+            )
+            .await?;
+        }
+        "/healthz" => {
+            write_http_response(&mut stream, 200, "text/plain; charset=utf-8", b"ok", &[]).await?;
+        }
+        _ => {
+            write_http_response(&mut stream, 404, "text/plain; charset=utf-8", b"not found", &[])
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+async fn write_http_response(
+    stream: &mut TcpStream,
+    status: u16,
+    content_type: &str,
+    body: &[u8],
+    extra_headers: &[(&str, &str)],
+) -> anyhow::Result<()> {
+    let reason = match status {
+        200 => "OK",
+        401 => "Unauthorized",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        _ => "Error",
+    };
+    let mut header = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n",
+        body.len()
+    );
+    for (name, value) in extra_headers {
+        header.push_str(&format!("{name}: {value}\r\n"));
+    }
+    header.push_str("\r\n");
+    stream.write_all(header.as_bytes()).await?;
+    stream.write_all(body).await?;
+    stream.shutdown().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server_limits::AuthRateLimiterConfig;
+
+    #[test]
+    fn prometheus_render_contains_core_metrics() {
+        let stats = ServerStats::new();
+        let auth = AuthRateLimiter::new(AuthRateLimiterConfig {
+            enabled: true,
+            ..Default::default()
+        });
+        stats.inc_handshake_success();
+        auth.auth_failures_total
+            .fetch_add(2, std::sync::atomic::Ordering::Relaxed);
+
+        let text = render_prometheus(&stats, &auth);
+        assert!(text.contains("bibavpn_active_sessions 0"));
+        assert!(text.contains("bibavpn_handshakes_success_total 1"));
+        assert!(text.contains("bibavpn_auth_failures_total 2"));
+        assert!(text.contains("# TYPE bibavpn_active_sessions gauge"));
+        assert!(text.contains("# TYPE bibavpn_auth_failures_total counter"));
+    }
+
+    #[tokio::test]
+    async fn metrics_http_healthz_and_metrics() {
+        let stats = ServerStats::new();
+        let auth = AuthRateLimiter::new(AuthRateLimiterConfig::default());
+        let metrics_auth = MetricsAuth::disabled();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let stats_c = Arc::clone(&stats);
+        let auth_c = Arc::clone(&auth);
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            serve_one_http(stream, &stats_c, &auth_c, &metrics_auth)
+                .await
+                .unwrap();
+        });
+
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        stream
+            .write_all(b"GET /healthz HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+        let mut resp = vec![0u8; 256];
+        let n = stream.read(&mut resp).await.unwrap();
+        let text = std::str::from_utf8(&resp[..n]).unwrap();
+        assert!(text.contains("200 OK"));
+        assert!(text.contains("ok"));
+    }
+
+    #[tokio::test]
+    async fn metrics_http_requires_password_when_configured() {
+        let stats = ServerStats::new();
+        let auth = AuthRateLimiter::new(AuthRateLimiterConfig::default());
+        let metrics_auth = MetricsAuth::basic("metrics", "s3cret");
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Unauthorized request.
+        let stats_c = Arc::clone(&stats);
+        let auth_c = Arc::clone(&auth);
+        let metrics_auth_c = metrics_auth.clone();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            serve_one_http(stream, &stats_c, &auth_c, &metrics_auth_c)
+                .await
+                .unwrap();
+        });
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        stream
+            .write_all(b"GET /metrics HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+        let mut resp = vec![0u8; 256];
+        let n = stream.read(&mut resp).await.unwrap();
+        let text = std::str::from_utf8(&resp[..n]).unwrap();
+        assert!(text.contains("401 Unauthorized"));
+        assert!(text.contains(r#"WWW-Authenticate: Basic realm="bibavpn-metrics""#));
+
+        // Authorized request (listener moved into the server task to avoid accept races).
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let stats_c = Arc::clone(&stats);
+        let auth_c = Arc::clone(&auth);
+        let metrics_auth_ok = MetricsAuth::basic("metrics", "s3cret");
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            serve_one_http(stream, &stats_c, &auth_c, &metrics_auth_ok)
+                .await
+                .unwrap();
+        });
+        let cred = base64::engine::general_purpose::STANDARD.encode(b"metrics:s3cret");
+        let req = format!(
+            "GET /metrics HTTP/1.1\r\nHost: localhost\r\nAuthorization: Basic {cred}\r\n\r\n"
+        );
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        stream.write_all(req.as_bytes()).await.unwrap();
+        let mut resp = vec![0u8; 4096];
+        let n = stream.read(&mut resp).await.unwrap();
+        server.await.unwrap();
+        let text = std::str::from_utf8(&resp[..n]).unwrap();
+        assert!(text.contains("200 OK"), "response: {text}");
+        assert!(text.contains("bibavpn_active_sessions"), "response: {text}");
+    }
+
+    #[test]
+    fn metrics_auth_basic_compare() {
+        let auth = MetricsAuth::basic("metrics", "s3cret");
+        let cred = base64::engine::general_purpose::STANDARD.encode(b"metrics:s3cret");
+        let headers = [("Authorization", format!("Basic {cred}"))];
+        let hdrs: Vec<(&str, &str)> = headers.iter().map(|(k, v)| (*k, v.as_str())).collect();
+        assert!(auth.authorize(&hdrs));
+        assert!(!auth.authorize(&[("Authorization", "Basic wrong")]));
+    }
+}


### PR DESCRIPTION
Add optional --metrics-listen HTTP listener with /metrics and /healthz, wire ServerStats and AuthRateLimiter counters, and optional HTTP Basic Auth via --metrics-password for production deployments.