### PR TITLE
fix(desktop): gate tunnel health probes to non-mobile (fix Android build, E0425)

### DIFF
--- a/apps/bibavpn-desktop/src-tauri/src/lib.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/lib.rs
@@ -375,6 +375,7 @@ fn probe_local_http_health(http_port: u16) -> bool {
     }
 }
 
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn probe_tunnel_end_to_end(http_port: u16) -> bool {
     use std::io::{Read, Write};
 
@@ -404,6 +405,7 @@ fn probe_tunnel_end_to_end(http_port: u16) -> bool {
     }
 }
 
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn tunnel_is_healthy(http_port: u16) -> bool {
     probe_local_http_health(http_port) && probe_tunnel_end_to_end(http_port)
 }


### PR DESCRIPTION
## Problem
`main` no longer builds for **Android/iOS** (CI `cargo build --target aarch64-linux-android`):

```
error[E0425]: cannot find function `probe_local_http_health` in this scope
   --> apps/bibavpn-desktop/src-tauri/src/lib.rs:408
note: found an item that was configured out
   --> apps/bibavpn-desktop/src-tauri/src/lib.rs:352
```

## Cause
The end-to-end health-probe change added two functions **without a target cfg gate**:
- `probe_tunnel_end_to_end` (lib.rs:378)
- `tunnel_is_healthy` (lib.rs:407) → calls `probe_local_http_health` (lib.rs:352), which is `#[cfg(not(any(target_os = "android", target_os = "ios")))]`.

On Android/iOS the callee is configured out, so `tunnel_is_healthy` fails to compile. Both functions' only callers are inside `spawn_tunnel_recovery_watch` (lib.rs:437/441/453), which is already desktop-only — so they are dead on mobile.

## Fix
Add `#[cfg(not(any(target_os = "android", target_os = "ios")))]` to `probe_tunnel_end_to_end` and `tunnel_is_healthy`. One file changed.

## Verification
- Desktop: `cargo check -p bibavpn-desktop` (VS 2022 Build Tools MSVC) — **green**, no unused-code warnings (both functions are still compiled and used on desktop via the recovery watch).
- Android/iOS: the offending symbols are removed from those targets, so the E0425 build failure is resolved. (Android CI/NDK not runnable in my env; verified by the cfg reasoning — callees, probes, and their sole caller are now all `not(android/ios)`.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
