### PR TITLE
fix(server): bound every pre-tunnel handshake phase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,7 +241,8 @@ balanced/aggressive default **10 s** unless overridden)
 that record splitting is not implemented (`desync::note_tls_fragment_requested`)
 - **Server:** `--ack-profile balanced|aggressive` if explicit `--server-ack-`* /
 `--rtt-mask-jitter-ms` are all zero; else set delays in milliseconds directly
-- **Server:** `--handshake-timeout-secs` (HELLO…`AUTH`, default **15**),
+- **Server:** `--handshake-timeout-secs` (per pre-tunnel phase: TLS accept, WS
+upgrade / camouflage HTTP head, REALITY exchange, HELLO…`AUTH`; default **15**),
 `--mux-connect-timeout-secs` (per mux stream outbound TCP connect, default **10**)
 - Server `--camouflage-dir`, `--camouflage-url` (`http://` upstream only)
 - **Logging (CLI):** server and client `--log-level`, `--log-format plain|json`;
@@ -317,8 +318,12 @@ accepted connection until it finishes).
 
 **Other server timeouts / telemetry:**
 
-- **`--handshake-timeout-secs`** — drop inbound sessions that never complete
-  HELLO…`AUTH` in time (default **15**).
+- **`--handshake-timeout-secs`** — drop inbound sessions that stall in any
+  pre-tunnel phase (default **15**, applied per phase): TLS accept, WebSocket
+  upgrade / camouflage HTTP head, REALITY exchange and its first application
+  frame, and the HELLO…`AUTH` wait. The concurrency permit is taken before any
+  peer I/O, so without this a silent socket would hold a session slot; expiry
+  counts in `bibavpn_handshake_timeouts_total` and releases the permit.
 - **`--mux-connect-timeout-secs`** — limit how long the server waits on each
   outbound **TCP connect** for a mux stream (default **10**).
 - **`--stats-interval-secs`** — periodic aggregate stats on the `bibavpn_server`

--- a/bibavpn/src/bin/server.rs
+++ b/bibavpn/src/bin/server.rs
@@ -208,7 +208,8 @@ struct Args {
     #[arg(long, default_value_t = 262144)]
     handshake_max_junk_bytes: usize,
 
-    /// Overall v3 handshake wait (HELLO..AUTH) timeout in seconds.
+    /// Per-phase pre-tunnel timeout in seconds: TLS accept, WS upgrade / camouflage HTTP head,
+    /// REALITY exchange, and the v3 handshake wait (HELLO..AUTH).
     #[arg(long, default_value_t = 15)]
     handshake_timeout_secs: u64,
 
@@ -953,6 +954,41 @@ where
     Ok(())
 }
 
+/// Bound one pre-tunnel setup phase (TLS accept, WS upgrade / camouflage HTTP head,
+/// REALITY exchange) with `dur`.
+///
+/// The concurrency permit and the session guard are taken before any peer I/O, so a
+/// peer that opens a socket and then stalls would otherwise hold a slot until it gives
+/// up: a handful of silent sockets can exhaust `--max-concurrent-sessions`. Expiry is
+/// counted as a handshake timeout and returns an error, which releases both.
+/// No `auth.record_failure`: a peer that never spoke has not failed authentication.
+async fn with_setup_timeout<T, F>(
+    phase: &'static str,
+    dur: Duration,
+    stats: &Arc<ServerStats>,
+    peer: SocketAddr,
+    session_id: u64,
+    fut: F,
+) -> anyhow::Result<T>
+where
+    F: std::future::Future<Output = anyhow::Result<T>>,
+{
+    match timeout(dur, fut).await {
+        Ok(r) => r,
+        Err(_) => {
+            let secs = dur.as_secs();
+            stats.inc_handshake_timeout();
+            debug!(
+                target: "bibavpn_server",
+                %peer,
+                session_id,
+                "pre-tunnel timeout in {phase} after {secs}s; releasing concurrency permit"
+            );
+            anyhow::bail!("{phase} timeout after {secs}s");
+        }
+    }
+}
+
 async fn handle_one(
     tcp: TcpStream,
     acceptor: TlsAcceptor,
@@ -987,11 +1023,34 @@ async fn handle_one(
     );
     let _span_enter = span.enter();
 
-    let tls = acceptor.accept(tcp).await.context("tls accept")?;
+    let tls = with_setup_timeout(
+        "tls accept",
+        params.handshake_timeout,
+        &params.stats,
+        params.peer,
+        params.session_id,
+        async move { acceptor.accept(tcp).await.context("tls accept") },
+    )
+    .await?;
 
-    let Some((mut ws, ws_kind)) =
-        accept_websocket_or_camouflage(tls, &ws_path, legacy_path_auth, &token, camo, Some(params.peer))
-            .await?
+    // Covers the HTTP head read (`incoming::read_http_head` has no deadline of its own)
+    // plus writing the camouflage answer; a real probe is served long before it expires.
+    let Some((mut ws, ws_kind)) = with_setup_timeout(
+        "websocket upgrade / camouflage http",
+        params.handshake_timeout,
+        &params.stats,
+        params.peer,
+        params.session_id,
+        accept_websocket_or_camouflage(
+            tls,
+            &ws_path,
+            legacy_path_auth,
+            &token,
+            camo,
+            Some(params.peer),
+        ),
+    )
+    .await?
     else {
         return Ok(());
     };
@@ -1018,18 +1077,38 @@ async fn handle_one(
 
     if let Some(ref reality_cfg) = reality_config {
         info!("REALITY mode: app tunnel after X25519");
-        server_handshake_reality(&mut ws, reality_cfg)
-            .await
-            .context("REALITY handshake")?;
+        with_setup_timeout(
+            "REALITY handshake",
+            handshake_timeout,
+            &params.stats,
+            params.peer,
+            params.session_id,
+            async {
+                server_handshake_reality(&mut ws, reality_cfg)
+                    .await
+                    .context("REALITY handshake")
+            },
+        )
+        .await?;
 
         let domain_trim = proto_domain.trim();
         if domain_trim.is_empty() {
             anyhow::bail!("--proto-domain must not be empty");
         }
 
-        let next = read_next_binary_after_reality(&mut ws)
-            .await
-            .context("after REALITY: first application frame")?;
+        let next = with_setup_timeout(
+            "first frame after REALITY",
+            handshake_timeout,
+            &params.stats,
+            params.peer,
+            params.session_id,
+            async {
+                read_next_binary_after_reality(&mut ws)
+                    .await
+                    .context("after REALITY: first application frame")
+            },
+        )
+        .await?;
 
         if is_v3_mux_open(next.as_ref()) {
             info!("REALITY: TCP mux (plaintext mux records)");

--- a/bibavpn/src/incoming.rs
+++ b/bibavpn/src/incoming.rs
@@ -395,12 +395,74 @@ Connection: close\r\n\
 mod tests {
     use super::*;
     use std::fs;
+    use std::time::Duration;
 
     #[test]
     fn guess_mime_common_extensions() {
         assert!(guess_mime("html").contains("text/html"));
         assert!(guess_mime("CSS").contains("text/css"));
         assert_eq!(guess_mime("bin"), "application/octet-stream");
+    }
+
+    /// `read_http_head` waits for `\r\n\r\n` with no deadline of its own, so the caller
+    /// must impose one: the server bounds this call with `--handshake-timeout-secs`
+    /// because the concurrency permit is already held here.
+    #[tokio::test]
+    async fn partial_http_head_never_completes_and_the_caller_deadline_fires() {
+        let (mut client, server) = tokio::io::duplex(4096);
+        // Request line + one header, never the terminating CRLF CRLF.
+        client
+            .write_all(b"GET / HTTP/1.1\r\nHost: example.org\r\n")
+            .await
+            .unwrap();
+        let res = tokio::time::timeout(
+            Duration::from_millis(50),
+            accept_websocket_or_camouflage(
+                server,
+                "/ws",
+                false,
+                "tok",
+                CamouflageServeConfig::default(),
+                None,
+            ),
+        )
+        .await;
+        assert!(
+            res.is_err(),
+            "a peer that never finishes the head must not resolve"
+        );
+        // Keep the peer half alive until here; dropping it earlier would be EOF, not a stall.
+        drop(client);
+    }
+
+    /// The timeout must not change the camouflage path: a complete probe is still served.
+    #[tokio::test]
+    async fn complete_http_head_still_gets_camouflage_response() {
+        let (mut client, server) = tokio::io::duplex(64 * 1024);
+        let srv = tokio::spawn(async move {
+            accept_websocket_or_camouflage(
+                server,
+                "/ws",
+                false,
+                "tok",
+                CamouflageServeConfig::default(),
+                None,
+            )
+            .await
+        });
+        client
+            .write_all(b"GET / HTTP/1.1\r\nHost: example.org\r\n\r\n")
+            .await
+            .unwrap();
+        let mut resp = vec![0u8; 4096];
+        let n = tokio::time::timeout(Duration::from_secs(5), client.read(&mut resp))
+            .await
+            .expect("camouflage answers well inside the handshake deadline")
+            .unwrap();
+        let text = String::from_utf8_lossy(&resp[..n]);
+        assert!(text.starts_with("HTTP/1.1 200 OK"), "got: {text}");
+        let out = srv.await.expect("join").expect("accept");
+        assert!(out.is_none(), "a plain GET is not a websocket upgrade");
     }
 
     #[test]

--- a/bibavpn/src/server_metrics.rs
+++ b/bibavpn/src/server_metrics.rs
@@ -86,7 +86,7 @@ bibavpn_auth_failures_total {auth_failures_total}
 # HELP bibavpn_auth_bans_issued_total Temporary auth bans issued since process start.
 # TYPE bibavpn_auth_bans_issued_total counter
 bibavpn_auth_bans_issued_total {auth_bans_issued_total}
-# HELP bibavpn_handshake_timeouts_total Handshakes that exceeded the AUTH wait timeout.
+# HELP bibavpn_handshake_timeouts_total Sessions that exceeded a pre-tunnel timeout (TLS, WS upgrade, REALITY, AUTH wait).
 # TYPE bibavpn_handshake_timeouts_total counter
 bibavpn_handshake_timeouts_total {handshake_timeouts_total}
 # HELP bibavpn_auth_rejected_banned_total Connections rejected because the source IP is banned.


### PR DESCRIPTION
## Проблема

Медленный или молчащий клиент бесконечно держал серверный слот конкурентности, поэтому горсть простаивающих TCP-соединений исчерпывала `--max-concurrent-sessions` и блокировала реальных пользователей.

Permit (`conn_sem`) и `stats.session_guard()` берутся **до** любого I/O с пиром, а дальше ни одна из фаз не имела таймаута:

- `acceptor.accept(tcp)` — TLS-хендшейк;
- `accept_websocket_or_camouflage(...)` — внутри `incoming::read_http_head` читает до `\r\n\r\n` с ограничением только по размеру (64 КиБ), без ограничения по времени;
- `server_handshake_reality(...)` в REALITY-режиме;
- `read_next_binary_after_reality(...)`.

Существующий `--handshake-timeout-secs` накрывал только ожидание v3 HELLO…AUTH. Код в этом же файле уже знает про этот класс проблем — см. комментарий про ограничение исходящего дозвона, «чтобы заблэкхоленная цель не занимала сессию (и её permit)».

## Что сделано

Новый хелпер `with_setup_timeout(phase, dur, stats, peer, session_id, fut)` рядом с `handle_one` ограничивает каждую предтуннельную фазу. При истечении: `stats.inc_handshake_timeout()`, `debug!` в `target: "bibavpn_server"` с фазой и пиром, и ошибка — так что permit и session guard освобождаются. `auth.record_failure` намеренно **не** вызывается: пир, который вообще ничего не сказал, не провалил аутентификацию.

Обёрнуты все четыре фазы: `tls accept`, `websocket upgrade / camouflage http`, `REALITY handshake`, `first frame after REALITY`. Уже существующие `timeout(handshake_timeout, ...)` в `server_handshake_v3` / `server_handshake_v3_after_first_hello` не тронуты, как и `wait_first_channel` и дозвон mux (пост-авторизация / уже ограничены).

Новый флаг не добавлялся: `--handshake-timeout-secs` (дефолт 15) уже настраиваемый, документированный и проброшен в `handle_one` через `ServerConnParams`, поэтому он теперь применяется **per-phase**. Обновлены его clap-описание, два места в `AGENTS.md` и HELP-строка `bibavpn_handshake_timeouts_total` (в `README.md` флаг не упоминается).

## Проверка

Два `#[tokio::test]` в существующий `mod tests` в `incoming.rs`, на `tokio::io::duplex`:

- пир пишет строку запроса и один заголовок, но никогда завершающий CRLF CRLF — дедлайн вызывающей стороны обязан сработать. Тест детерминирован: future в принципе не может завершиться, а половина пира намеренно держится живой, чтобы это был именно стоп, а не EOF;
- полный `GET /` по-прежнему получает `HTTP/1.1 200 OK` задолго до бюджета — камуфляж не сломан.

`tokio::time::pause` не используется: фича `test-util` в воркспейсе не включена и `[dev-dependencies]` нет, это потребовало бы правки Cargo.toml без выигрыша.

Локально workspace не собирается (на машине нет MSVC-линкера), сборку проверяет CI этого PR; `rustfmt --check` не даёт хунков в добавленном коде.

## На что смотреть ревьюеру

Обёртка вокруг всего `accept_websocket_or_camouflage` заодно ограничивает 15 секундами и reverse-proxy камуфляжа (`--camouflage-url`: коннект к origin + перекладывание ответа). Считаю это правильным — заблэкхоленный origin течёт permit'ами точно так же, как заблэкхоленный дозвон mux, о котором предупреждает существующий комментарий — но это единственная фаза, где поведение меняется не только для зависших пиров. Оставить её полностью неограниченной означало бы добавить параметр `head_timeout` в публичную `accept_websocket_or_camouflage` и править два места в `bibavpn/tests/reality_handshake.rs`; выбран меньший диff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
