### PR TITLE
fix(server): rate-limit auth per IPv6 /64, not per address

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,8 +304,10 @@ logs a one-line summary via `transport_capabilities::log_server_listen_caps`):
   accept waits **up to 5 seconds** for a permit; if none is available, the TCP
   is dropped and a `bibavpn_security` line records the timeout (server busy).
 - **`--no-auth-rate-limit`** / **`--auth-max-failures`** /
-  **`--auth-failure-window-secs`** / **`--auth-ban-secs`** — per-IP limits on
-  failed tunnel `AUTH` (see `server_limits::AuthRateLimiter`).
+  **`--auth-failure-window-secs`** / **`--auth-ban-secs`** — per-source limits
+  on failed tunnel `AUTH` (see `server_limits::AuthRateLimiter`). Counted per
+  bucket, **IPv4 /32** and **IPv6 /64** (`server_limits::auth_limit_key`), so a
+  routed IPv6 prefix cannot rotate source addresses to dodge the ban.
 - **`--handshake-max-junk-bytes`** (+ internal frame/decrypt budgets) — bounds
   pre-`AUTH` noise before `AUTH` completes (`server_limits::PreAuthBudget`).
 - **`--udp-socket-pool-size`** — reuse up to N UDP sockets on the UDP mux path

--- a/bibavpn/src/server_limits.rs
+++ b/bibavpn/src/server_limits.rs
@@ -1,7 +1,8 @@
-//! Per-IP auth rate limiting, handshake junk budgets, and server-wide session counters.
+//! Per-source auth rate limiting (IPv4 /32, IPv6 /64), handshake junk budgets,
+//! and server-wide session counters.
 
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -9,6 +10,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
 /// Sliding window: `max_failures` within `window`, then ban for `ban`.
+/// Counted per source bucket (IPv4 /32, IPv6 /64), see [`auth_limit_key`].
 #[derive(Debug, Clone)]
 pub struct AuthRateLimiterConfig {
     pub enabled: bool,
@@ -39,8 +41,52 @@ struct IpAuthState {
 /// shrank on a *successful* auth, so failed handshakes grew it without bound.
 const MAX_TRACKED_IPS: usize = 100_000;
 
+/// Prefix length used to bucket IPv6 peers for auth accounting. A /64 is the
+/// smallest end-site allocation that is routed on the public internet (a single
+/// host normally gets one, and /48s are common), so every address an attacker
+/// can source without extra routing shares one bucket. Anything longer would
+/// let a single host mint a fresh failure budget per source address.
+const IPV6_AUTH_PREFIX_BITS: u32 = 64;
+
+/// Zero all bits below `prefix_bits` of an IPv6 address. `prefix_bits >= 128`
+/// keeps the address as-is; `0` collapses everything to `::`.
+fn mask_ipv6(addr: Ipv6Addr, prefix_bits: u32) -> Ipv6Addr {
+    let bits = u128::from(addr);
+    let mask = match 128u32.checked_sub(prefix_bits) {
+        Some(shift) if shift < 128 => !0u128 << shift,
+        // /0: one bucket for everything.
+        Some(_) => 0,
+        // Longer than /128: no masking.
+        None => !0u128,
+    };
+    Ipv6Addr::from(bits & mask)
+}
+
+/// Bucket key under which auth failures and bans are accounted.
+///
+/// IPv4 keeps full /32 precision. IPv6 is masked to `IPV6_AUTH_PREFIX_BITS`,
+/// otherwise a peer with a routed prefix gets a fresh failure window per source
+/// address and `max_failures` never triggers.
+///
+/// IPv4-mapped peers (`::ffff:203.0.113.1`, seen on dual-stack sockets) are
+/// canonicalized to their IPv4 form *before* masking, so they share a bucket
+/// with the plain IPv4 address instead of collapsing the whole IPv4 space into
+/// one `::ffff:0:0/64` bucket. IPv4-compatible (`::a.b.c.d`) is deprecated and
+/// not routed, so it is left to fall into the `::/64` bucket: stricter than
+/// per-address, never looser.
+pub fn auth_limit_key(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V4(_) => ip,
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => IpAddr::V4(v4),
+            None => IpAddr::V6(mask_ipv6(v6, IPV6_AUTH_PREFIX_BITS)),
+        },
+    }
+}
+
 pub struct AuthRateLimiter {
     cfg: AuthRateLimiterConfig,
+    /// Keyed by [`auth_limit_key`], not by the raw peer address.
     inner: Mutex<HashMap<IpAddr, IpAuthState>>,
     pub bans_active: AtomicU64,
     pub auth_failures_total: AtomicU64,
@@ -58,14 +104,15 @@ impl AuthRateLimiter {
         })
     }
 
-    /// Fail fast if IP is banned; clear expired bans.
+    /// Fail fast if the peer's bucket is banned; clear expired bans.
     pub async fn check_allowed(self: &Arc<Self>, ip: IpAddr) -> anyhow::Result<()> {
         if !self.cfg.enabled {
             return Ok(());
         }
+        let key = auth_limit_key(ip);
         let mut g = self.inner.lock().await;
         let now = Instant::now();
-        let st = match g.get_mut(&ip) {
+        let st = match g.get_mut(&key) {
             Some(s) => s,
             None => return Ok(()),
         };
@@ -99,9 +146,10 @@ impl AuthRateLimiter {
         if !self.cfg.enabled {
             return;
         }
+        let key = auth_limit_key(ip);
         let mut g = self.inner.lock().await;
         let now = Instant::now();
-        if g.len() >= MAX_TRACKED_IPS && !g.contains_key(&ip) {
+        if g.len() >= MAX_TRACKED_IPS && !g.contains_key(&key) {
             self.prune_locked(&mut g, now);
             if g.len() >= MAX_TRACKED_IPS {
                 // Still full of active windows/bans: evict the oldest entry that
@@ -121,7 +169,7 @@ impl AuthRateLimiter {
                 }
             }
         }
-        let st = g.entry(ip).or_insert(IpAuthState {
+        let st = g.entry(key).or_insert(IpAuthState {
             failures: 0,
             window_start: now,
             banned_until: None,
@@ -148,13 +196,14 @@ impl AuthRateLimiter {
         }
     }
 
-    /// Clear per-IP failure state after successful AUTH (entry removed).
+    /// Clear the bucket's failure state after successful AUTH (entry removed).
     pub async fn record_success(self: &Arc<Self>, ip: IpAddr) {
         if !self.cfg.enabled {
             return;
         }
+        let key = auth_limit_key(ip);
         let mut g = self.inner.lock().await;
-        if let Some(st) = g.remove(&ip) {
+        if let Some(st) = g.remove(&key) {
             if let Some(until) = st.banned_until {
                 if Instant::now() < until {
                     let _ = self.bans_active.fetch_sub(1, Ordering::Relaxed);
@@ -278,6 +327,10 @@ impl Drop for SessionGuard {
 mod tests {
     use super::*;
 
+    fn key(s: &str) -> IpAddr {
+        auth_limit_key(s.parse().unwrap())
+    }
+
     #[tokio::test]
     async fn rate_limit_ban_then_expire() {
         let cfg = AuthRateLimiterConfig {
@@ -314,5 +367,118 @@ mod tests {
         lim.record_success(ip).await;
         lim.record_failure(ip).await;
         lim.check_allowed(ip).await.unwrap();
+    }
+
+    #[test]
+    fn ipv6_keys_collapse_to_64() {
+        // Same /64, different interface IDs: one bucket, equal to the prefix.
+        let want: IpAddr = "2001:db8:1:2::".parse().unwrap();
+        assert_eq!(key("2001:db8:1:2::1"), want);
+        assert_eq!(key("2001:db8:1:2:ffff:ffff:ffff:ffff"), want);
+        assert_eq!(key("2001:db8:1:2::1"), key("2001:db8:1:2:dead:beef:1:2"));
+    }
+
+    #[test]
+    fn ipv6_keys_differ_across_64s() {
+        assert_ne!(key("2001:db8:1:2::1"), key("2001:db8:1:3::1"));
+        // Neighbouring /48s too.
+        assert_ne!(key("2001:db8:1:2::1"), key("2001:db8:2:2::1"));
+    }
+
+    #[test]
+    fn ipv4_keys_are_per_address() {
+        assert_eq!(key("203.0.113.1"), "203.0.113.1".parse::<IpAddr>().unwrap());
+        assert_ne!(key("203.0.113.1"), key("203.0.113.2"));
+    }
+
+    #[test]
+    fn ipv4_mapped_v6_shares_ipv4_bucket() {
+        assert_eq!(key("::ffff:203.0.113.1"), key("203.0.113.1"));
+        // ...and does not swallow the whole ::ffff:0:0/64 into one bucket.
+        assert_ne!(key("::ffff:203.0.113.1"), key("::ffff:203.0.113.2"));
+    }
+
+    #[test]
+    fn mask_ipv6_edge_prefixes() {
+        let a: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        assert_eq!(mask_ipv6(a, 128), a);
+        assert_eq!(mask_ipv6(a, 0), Ipv6Addr::UNSPECIFIED);
+        assert_eq!(mask_ipv6(a, 32), "2001:db8::".parse::<Ipv6Addr>().unwrap());
+    }
+
+    #[tokio::test]
+    async fn ipv6_rotation_within_64_is_banned() {
+        let lim = AuthRateLimiter::new(AuthRateLimiterConfig {
+            enabled: true,
+            max_failures: 3,
+            window: Duration::from_secs(60),
+            ban: Duration::from_millis(50),
+        });
+        // Three failures spread over three distinct /128s in one /64.
+        for a in ["2001:db8:1:2::1", "2001:db8:1:2::2", "2001:db8:1:2::3"] {
+            let ip: IpAddr = a.parse().unwrap();
+            lim.check_allowed(ip).await.unwrap();
+            lim.record_failure(ip).await;
+        }
+        assert_eq!(lim.bans_active.load(Ordering::Relaxed), 1);
+        assert_eq!(lim.auth_bans_issued_total.load(Ordering::Relaxed), 1);
+        // A fourth, so far unseen address in the same /64 is banned too.
+        let fresh: IpAddr = "2001:db8:1:2:aaaa::9".parse().unwrap();
+        assert!(lim.check_allowed(fresh).await.is_err());
+
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        lim.check_allowed(fresh).await.unwrap();
+        assert_eq!(lim.bans_active.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn ipv6_rotation_across_64s_is_not_banned() {
+        let lim = AuthRateLimiter::new(AuthRateLimiterConfig {
+            enabled: true,
+            max_failures: 3,
+            window: Duration::from_secs(60),
+            ban: Duration::from_secs(300),
+        });
+        for a in ["2001:db8:1:1::1", "2001:db8:1:2::1", "2001:db8:1:3::1"] {
+            let ip: IpAddr = a.parse().unwrap();
+            lim.record_failure(ip).await;
+            lim.check_allowed(ip).await.unwrap();
+        }
+        assert_eq!(lim.bans_active.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn ipv4_addresses_stay_independent() {
+        let lim = AuthRateLimiter::new(AuthRateLimiterConfig {
+            enabled: true,
+            max_failures: 2,
+            window: Duration::from_secs(60),
+            ban: Duration::from_secs(300),
+        });
+        let a: IpAddr = "203.0.113.1".parse().unwrap();
+        let b: IpAddr = "203.0.113.2".parse().unwrap();
+        lim.record_failure(a).await;
+        lim.record_failure(a).await;
+        assert!(lim.check_allowed(a).await.is_err());
+        // Same /24, unrelated bucket.
+        lim.check_allowed(b).await.unwrap();
+        assert_eq!(lim.bans_active.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn ipv4_mapped_peer_shares_ban_with_ipv4() {
+        let lim = AuthRateLimiter::new(AuthRateLimiterConfig {
+            enabled: true,
+            max_failures: 2,
+            window: Duration::from_secs(60),
+            ban: Duration::from_secs(300),
+        });
+        let mapped: IpAddr = "::ffff:203.0.113.7".parse().unwrap();
+        let plain: IpAddr = "203.0.113.7".parse().unwrap();
+        lim.record_failure(mapped).await;
+        lim.record_failure(plain).await;
+        assert!(lim.check_allowed(mapped).await.is_err());
+        assert!(lim.check_allowed(plain).await.is_err());
+        assert_eq!(lim.bans_active.load(Ordering::Relaxed), 1);
     }
 }


### PR DESCRIPTION
## Проблема

`AuthRateLimiter` вёл скользящее окно и баны по точному адресу пира (`HashMap<IpAddr, IpAuthState>`). Атакующий с маршрутизируемым IPv6-префиксом — /64 это обычная выдача на один хост, /48 тоже не редкость — получал свежий бакет на каждый source-адрес, поэтому `--auth-max-failures` не срабатывал никогда.

Комментарий в самом файле форму проблемы уже признаёт («Hard cap on tracked source IPs, to bound memory under IP-rotation floods (e.g. an attacker cycling through a /64)»), но логика бана оставалась per-/128: память ограничена, а количество попыток аутентификации — нет.

## Что сделано

```rust
pub fn auth_limit_key(ip: IpAddr) -> IpAddr
fn mask_ipv6(addr: Ipv6Addr, prefix_bits: u32) -> Ipv6Addr
const IPV6_AUTH_PREFIX_BITS: u32 = 64;
```

IPv4 сохраняет полную точность /32. IPv6 сначала проходит `to_ipv4_mapped()` (чтобы `::ffff:203.0.113.1` попал в бакет `203.0.113.1`, а не собрал весь IPv4-интернет в один `::ffff:0:0/64`), иначе обнуляются младшие 64 бита. `mask_ipv6` тотальна: `/0` → `::`, `>= /128` → тождество, без паники на переполнении сдвига.

IPv4-compatible (`::a.b.c.d`) намеренно **не** канонизируется: формат устаревший и не маршрутизируется, поэтому падает в бакет `::/64` — строже, чем per-address, и никогда не слабее. Это исключает теоретический путь, где v6-пир отравляет бакет настоящего IPv4-клиента.

Ключ применяется во всех точках входа (`check_allowed`, `record_failure`, `record_success`). Проверка `MAX_TRACKED_IPS` теперь смотрит `contains_key(&key)` — правильная пара к `entry(key)` ниже; проверка по сырому IP была бы реальным багом, вызывая prune/eviction на каждый ротированный адрес внутри уже отслеживаемого /64.

Длина префикса — именованная константа, а не CLI-флаг: флаг потребовал бы правки `bin/server.rs`, который сейчас параллельно меняют три других PR, ради ручки, которую никто не просил.

## Инварианты, которые проверены отдельно

Изменились только **ключи** карты, арифметика не тронута. `prune_locked` работает без учёта ключа (`retain(|_, st| …)`), поэтому его `bans_active.fetch_sub` не затронут. Блок eviction в `record_failure` итерируется по существующим ключам, то есть уже по бакетам, и удаляет только небанненые записи — корректировка гейджа там не нужна, как и раньше. Декременты в `check_allowed` / `record_failure` / `record_success` не менялись: на каждый `fetch_add` по-прежнему ровно один `fetch_sub` в пределах жизни записи.

Логи не изменились и по-прежнему показывают **реальный** адрес пира (`%peer` / `%peer_ip` в `bibavpn_security`); бакет остаётся внутренней деталью лимитера и наружу не всплывает. Вызовы в `bin/server.rs` править не потребовалось.

## Проверка

Чистые тесты: коллапс IPv6-ключей в /64, различие между разными /64, независимость IPv4-адресов, IPv4-mapped в одном бакете с IPv4, граничные префиксы `mask_ipv6` (/0, /32, /128).

`#[tokio::test]`: ротация внутри /64 приводит к бану (3 провала с 3 разных /128 → бан, `bans_active == 1`, `auth_bans_issued_total == 1`, четвёртый невиданный адрес того же /64 отклонён, после истечения бана `bans_active` снова 0); ротация между разными /64 к бану не приводит; IPv4-адреса остаются независимыми; IPv4-mapped пир делит бан с IPv4-формой.

Локально workspace не собирается (на машине нет MSVC-линкера), сборку проверяет CI этого PR.

## Смысловое следствие для ревьюера

Успешная аутентификация теперь очищает состояние всего бакета, то есть один валидный клиент в /64 сбрасывает счётчики провалов для этого /64. На практике легитимный клиент не может дойти до AUTH, пока его бакет забанен (`check_allowed` вызывается на accept), так что очищаются только незавершённые окна провалов, но не активные баны.

Отдельно: HELP-текст `bibavpn_auth_bans_active` в `server_metrics.rs` всё ещё говорит «Source IPs currently under temporary auth ban» — теперь это бакеты. Оставлено как есть, чтобы не менять вывод метрик; правка формулировки уместна отдельным PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
