### PR TITLE
fix(server): keep serving after a failed accept(2)

### DIFF
--- a/bibavpn/src/bin/server.rs
+++ b/bibavpn/src/bin/server.rs
@@ -7,6 +7,7 @@ use anyhow::Context;
 use bibavpn::crypto_layer::{self, SessionCrypto};
 use bibavpn::frame::{AdaptivePadState, PadMode, DEFAULT_MAX_WS_BINARY};
 use bibavpn::incoming::{accept_websocket_or_camouflage, CamouflageServeConfig, WsHandshakeKind};
+use bibavpn::log_ratelimit::LogEvery;
 use bibavpn::logging::{self, LogConfig, LogFormat};
 use bibavpn::server_limits::{
     AuthRateLimiter, AuthRateLimiterConfig, PreAuthBudget, ServerStats,
@@ -263,6 +264,81 @@ struct Args {
 }
 
 type SharedCrypto = Arc<SessionCrypto>;
+
+/// Pause after an accept error that would otherwise repeat immediately.
+const ACCEPT_BACKOFF: Duration = Duration::from_millis(100);
+
+/// What the accept loop does after a failed `accept(2)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AcceptRecovery {
+    /// Per-connection failure (peer vanished, signal): retry immediately.
+    RetryNow,
+    /// Sleep before retrying, otherwise the loop spins at 100% CPU for as long
+    /// as the condition lasts. `exhaustion` marks the out-of-descriptors /
+    /// out-of-buffers class so the log says so.
+    RetryAfterBackoff { exhaustion: bool },
+}
+
+impl AcceptRecovery {
+    fn backoff(self) -> Option<Duration> {
+        match self {
+            AcceptRecovery::RetryNow => None,
+            AcceptRecovery::RetryAfterBackoff { .. } => Some(ACCEPT_BACKOFF),
+        }
+    }
+
+    fn is_exhaustion(self) -> bool {
+        matches!(self, AcceptRecovery::RetryAfterBackoff { exhaustion: true })
+    }
+}
+
+/// True for raw OS errors meaning "out of descriptors or kernel buffers".
+/// These have no distinct `std::io::ErrorKind` on stable Rust, so they are
+/// matched numerically; the values are per-platform ABI constants.
+#[cfg(unix)]
+fn is_accept_resource_exhaustion(code: i32) -> bool {
+    // EMFILE, ENFILE and ENOMEM share values across Linux and the BSDs;
+    // ENOBUFS does not.
+    const EMFILE: i32 = 24;
+    const ENFILE: i32 = 23;
+    const ENOMEM: i32 = 12;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    const ENOBUFS: i32 = 105;
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    const ENOBUFS: i32 = 55;
+    matches!(code, EMFILE | ENFILE | ENOMEM | ENOBUFS)
+}
+
+#[cfg(windows)]
+fn is_accept_resource_exhaustion(code: i32) -> bool {
+    // WSAEMFILE, WSAENOBUFS, WSAETOOMANYREFS.
+    matches!(code, 10024 | 10055 | 10059)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn is_accept_resource_exhaustion(_code: i32) -> bool {
+    false
+}
+
+/// Classify an `accept(2)` error. Never fatal: see the accept loop comment.
+fn classify_accept_error(e: &std::io::Error) -> AcceptRecovery {
+    use std::io::ErrorKind;
+    match e.kind() {
+        // Cheap and clearly per-connection: the next accept can succeed at once.
+        ErrorKind::ConnectionAborted
+        | ErrorKind::ConnectionReset
+        | ErrorKind::Interrupted
+        | ErrorKind::WouldBlock => AcceptRecovery::RetryNow,
+        // ENOMEM where the platform maps it to a kind.
+        ErrorKind::OutOfMemory => AcceptRecovery::RetryAfterBackoff { exhaustion: true },
+        // EMFILE/ENFILE/ENOBUFS have no stable `ErrorKind`, so check the raw
+        // code. Unrecognised errors back off as well: losing 100ms of accept
+        // throughput is cheaper than spinning on an error we do not know.
+        _ => AcceptRecovery::RetryAfterBackoff {
+            exhaustion: e.raw_os_error().is_some_and(is_accept_resource_exhaustion),
+        },
+    }
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -626,8 +702,38 @@ async fn main() -> anyhow::Result<()> {
         info!("SpiderX background crawler started for {}", cfg.target);
     }
 
+    // A failed accept(2) must never take the listener down: EMFILE/ENFILE/ENOBUFS
+    // (fd or kernel-buffer exhaustion, i.e. exactly what a connection flood
+    // produces) and ECONNABORTED (peer gone between SYN and accept) are all
+    // transient, and a proxy that exits on them is trivially DoS-able. Neither
+    // tokio nor the OS reports a permanently dead listener distinguishably here,
+    // so no error is treated as fatal; a listener that never recovers shows up as
+    // a climbing bibavpn_accepts_failed_total plus these rate-limited warnings.
+    static ACCEPT_ERR_LOG: LogEvery = LogEvery::new(8, 256);
     loop {
-        let (stream, peer) = listener.accept().await?;
+        let (stream, peer) = match listener.accept().await {
+            Ok(v) => v,
+            Err(e) => {
+                stats.inc_accept_failed();
+                let recovery = classify_accept_error(&e);
+                let backoff = recovery.backoff();
+                if ACCEPT_ERR_LOG.should_emit() {
+                    warn!(
+                        target: "bibavpn_server",
+                        error_kind = ?e.kind(),
+                        errno = e.raw_os_error().unwrap_or(0),
+                        resource_exhaustion = recovery.is_exhaustion(),
+                        backoff_ms = backoff.map(|d| d.as_millis() as u64).unwrap_or(0),
+                        accepts_failed_total = stats.accepts_failed_total.load(Ordering::Relaxed),
+                        "accept failed, still serving: {e:#}"
+                    );
+                }
+                if let Some(d) = backoff {
+                    tokio::time::sleep(d).await;
+                }
+                continue;
+            }
+        };
         let acceptor = acceptor.clone();
         let token = token.clone();
         let ws_path = ws_path.clone();
@@ -1344,6 +1450,71 @@ where
             Message::Close(_) => anyhow::bail!("closed before v3 AUTH"),
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Error, ErrorKind};
+
+    #[test]
+    fn transient_per_connection_accept_errors_retry_immediately() {
+        for kind in [
+            ErrorKind::ConnectionAborted,
+            ErrorKind::ConnectionReset,
+            ErrorKind::Interrupted,
+            ErrorKind::WouldBlock,
+        ] {
+            let r = classify_accept_error(&Error::from(kind));
+            assert_eq!(r, AcceptRecovery::RetryNow, "kind {kind:?}");
+            assert_eq!(r.backoff(), None, "kind {kind:?}");
+            assert!(!r.is_exhaustion(), "kind {kind:?}");
+        }
+    }
+
+    #[test]
+    fn out_of_memory_accept_error_backs_off() {
+        let r = classify_accept_error(&Error::from(ErrorKind::OutOfMemory));
+        assert_eq!(r, AcceptRecovery::RetryAfterBackoff { exhaustion: true });
+        assert_eq!(r.backoff(), Some(ACCEPT_BACKOFF));
+    }
+
+    #[test]
+    fn unknown_accept_error_backs_off_without_exhaustion_flag() {
+        let r = classify_accept_error(&Error::from(ErrorKind::PermissionDenied));
+        assert_eq!(r, AcceptRecovery::RetryAfterBackoff { exhaustion: false });
+        assert_eq!(r.backoff(), Some(ACCEPT_BACKOFF));
+    }
+
+    // Raw codes for the current platform: EMFILE, ENFILE, ENOMEM, ENOBUFS
+    // (WSAEMFILE, WSAENOBUFS, WSAETOOMANYREFS on Windows). Most have no stable
+    // `ErrorKind`, which is the case the raw-code rule exists for.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    const EXHAUSTION_CODES: &[i32] = &[24, 23, 12, 105];
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+    const EXHAUSTION_CODES: &[i32] = &[24, 23, 12, 55];
+    #[cfg(windows)]
+    const EXHAUSTION_CODES: &[i32] = &[10024, 10055, 10059];
+    #[cfg(not(any(unix, windows)))]
+    const EXHAUSTION_CODES: &[i32] = &[];
+
+    #[test]
+    fn descriptor_exhaustion_accept_errors_back_off() {
+        for &code in EXHAUSTION_CODES {
+            let r = classify_accept_error(&Error::from_raw_os_error(code));
+            assert!(
+                r.is_exhaustion(),
+                "errno {code} should be exhaustion: {r:?}"
+            );
+            assert_eq!(r.backoff(), Some(ACCEPT_BACKOFF), "errno {code}");
+        }
+    }
+
+    #[test]
+    fn accept_backoff_is_short() {
+        assert!(ACCEPT_BACKOFF >= Duration::from_millis(50));
+        assert!(ACCEPT_BACKOFF <= Duration::from_millis(250));
     }
 }
 

--- a/bibavpn/src/server_limits.rs
+++ b/bibavpn/src/server_limits.rs
@@ -216,6 +216,8 @@ pub struct ServerStats {
     pub sessions_rejected_busy_total: AtomicU64,
     pub handshakes_success_total: AtomicU64,
     pub session_errors_total: AtomicU64,
+    /// Failed `accept(2)` calls the listener loop recovered from.
+    pub accepts_failed_total: AtomicU64,
     pub started_at: Instant,
 }
 
@@ -228,6 +230,7 @@ impl ServerStats {
             sessions_rejected_busy_total: AtomicU64::new(0),
             handshakes_success_total: AtomicU64::new(0),
             session_errors_total: AtomicU64::new(0),
+            accepts_failed_total: AtomicU64::new(0),
             started_at: Instant::now(),
         })
     }
@@ -261,6 +264,10 @@ impl ServerStats {
 
     pub fn inc_session_error(&self) {
         self.session_errors_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_accept_failed(&self) {
+        self.accepts_failed_total.fetch_add(1, Ordering::Relaxed);
     }
 }
 

--- a/bibavpn/src/server_metrics.rs
+++ b/bibavpn/src/server_metrics.rs
@@ -101,6 +101,9 @@ bibavpn_handshakes_success_total {handshakes_success_total}
 # HELP bibavpn_session_errors_total Accepted sessions that ended with an error after TLS accept.
 # TYPE bibavpn_session_errors_total counter
 bibavpn_session_errors_total {session_errors_total}
+# HELP bibavpn_accepts_failed_total Failed accept(2) calls the listener loop recovered from.
+# TYPE bibavpn_accepts_failed_total counter
+bibavpn_accepts_failed_total {accepts_failed_total}
 # HELP bibavpn_process_start_time_seconds Start time of the process since the Unix epoch.
 # TYPE bibavpn_process_start_time_seconds gauge
 bibavpn_process_start_time_seconds {process_start}
@@ -127,6 +130,9 @@ bibavpn_process_start_time_seconds {process_start}
             .load(std::sync::atomic::Ordering::Relaxed),
         session_errors_total = stats
             .session_errors_total
+            .load(std::sync::atomic::Ordering::Relaxed),
+        accepts_failed_total = stats
+            .accepts_failed_total
             .load(std::sync::atomic::Ordering::Relaxed),
         process_start = process_start,
     )
@@ -285,12 +291,14 @@ mod tests {
             ..Default::default()
         });
         stats.inc_handshake_success();
+        stats.inc_accept_failed();
         auth.auth_failures_total
             .fetch_add(2, std::sync::atomic::Ordering::Relaxed);
 
         let text = render_prometheus(&stats, &auth);
         assert!(text.contains("bibavpn_active_sessions 0"));
         assert!(text.contains("bibavpn_handshakes_success_total 1"));
+        assert!(text.contains("bibavpn_accepts_failed_total 1"));
         assert!(text.contains("bibavpn_auth_failures_total 2"));
         assert!(text.contains("# TYPE bibavpn_active_sessions gauge"));
         assert!(text.contains("# TYPE bibavpn_auth_failures_total counter"));


### PR DESCRIPTION
## Проблема

Цикл приёма соединений в `main` начинался с

```rust
let (stream, peer) = listener.accept().await?;
```

Одна транзиентная ошибка `accept(2)` завершала весь цикл, и сервер перестаёт обслуживать. А транзиентные ошибки в продакшене нормальны: `EMFILE`/`ENFILE` (исчерпание дескрипторов — ровно то, что вызывает флуд соединений), `ECONNABORTED` (пир ушёл между SYN и accept), `ENOBUFS`/`ENOMEM`. Прокси, который на этом выходит, тривиально роняется DoS'ом.

## Что сделано

Ошибка accept больше не выходит из цикла. Классификация вынесена в чистую функцию:

```rust
enum AcceptRecovery { RetryNow, RetryAfterBackoff { exhaustion: bool } }
fn classify_accept_error(&std::io::Error) -> AcceptRecovery
```

- `ConnectionAborted | ConnectionReset | Interrupted | WouldBlock` → повтор немедленно, без сна;
- `ErrorKind::OutOfMemory` → бэкофф, класс «исчерпание»;
- остальное → бэкофф, где флаг `exhaustion` определяется по raw OS-коду: `EMFILE 24 / ENFILE 23 / ENOMEM 12` плюс `ENOBUFS` (105 на linux/android, 55 на прочих unix), а на Windows `10024 / 10055 / 10059` (WSAEMFILE / WSAENOBUFS / WSAETOOMANYREFS). У этих ошибок нет отдельного `ErrorKind` на stable Rust, поэтому сверка численная. Неизвестные ошибки тоже уходят в бэкофф: потерять 100 мс пропускной способности accept дешевле, чем крутиться на ошибке, которую мы не понимаем. Флаг `exhaustion` влияет только на поле в логе, не на решение.

`ACCEPT_BACKOFF` = 100 мс. При ошибке инкрементируется счётчик, пишется rate-limited `warn!` (через существующий `log_ratelimit::LogEvery`, с полями `error_kind`, `errno`, `resource_exhaustion`, `backoff_ms`, `accepts_failed_total`), при необходимости сон, затем `continue`.

Фатальных ошибок нет и ограничения на число повторов нет — доступность и есть смысл этой правки. Комментарий над циклом объясняет, что ни tokio, ни ОС не дают здесь отличить навсегда умерший листенер, и что такое состояние видно по растущему `bibavpn_accepts_failed_total` и этим предупреждениям.

Метрика добавлена (это оказалось дёшево): `ServerStats::accepts_failed_total` + `inc_accept_failed()` и строка `bibavpn_accepts_failed_total` в выводе Prometheus. `ServerStats` конструируется только через `ServerStats::new()` (проверено по всему репозиторию), так что новое поле ничего не ломает.

## Проверка

Пять юнит-тестов над синтезированными `std::io::Error` (без реального исчерпания дескрипторов и без зависимости от времени): транзиентные kind'ы → `RetryNow`/`backoff() == None`; `OutOfMemory` → бэкофф с флагом исчерпания; `PermissionDenied` → бэкофф без флага; таблица `EXHAUSTION_CODES` под платформу через `Error::from_raw_os_error` → флаг и бэкофф; и проверка, что `ACCEPT_BACKOFF` остаётся в диапазоне 50–250 мс. Плюс `bibavpn_accepts_failed_total 1` в существующем тесте рендера метрик.

Локально workspace не собирается (на машине нет MSVC-линкера), сборку проверяет CI этого PR.

## Мелочь для ревьюера

Не проверено компиляцией, все ли платформы отображают `ENOMEM`/`WSAENOBUFS` в `ErrorKind::OutOfMemory`. Обе ветки дают `exhaustion: true`, так что поведение и тесты верны в любом случае; то же касается гипотетического будущего Rust, который даст `EMFILE`/`ENFILE` именованный `ErrorKind` — ветка `_` всё равно смотрит raw-код.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
