### PR TITLE
fix(security): compare session secrets in constant time

### DIFF
--- a/bibavpn/src/bin/server.rs
+++ b/bibavpn/src/bin/server.rs
@@ -1324,7 +1324,7 @@ where
                 };
                 let inner = read_padded_frame_into(raw).context("v3 auth frame")?;
                 let tok = decode_v3_auth(&inner).context("decode v3 auth")?;
-                if tok != expected_token {
+                if !crypto_layer::secret_eq(tok.as_str(), expected_token) {
                     auth.record_failure(peer_ip).await;
                     warn!(
                         target: "bibavpn_security",

--- a/bibavpn/src/crypto_layer.rs
+++ b/bibavpn/src/crypto_layer.rs
@@ -24,6 +24,17 @@ pub const V3_HELLO_MIN_WIRE_LEN: usize = 1 + 32 + 1;
 
 const MAC_LEN: usize = 16;
 
+/// Compare a received secret (token, password, MAC) against the expected one without
+/// leaking how many leading bytes matched.
+///
+/// Only the content comparison is constant time. The length check short-circuits, so the
+/// length of `got` relative to `expected` is still observable; secret lengths are not hidden.
+pub fn secret_eq(got: impl AsRef<[u8]>, expected: impl AsRef<[u8]>) -> bool {
+    let got = got.as_ref();
+    let expected = expected.as_ref();
+    got.len() == expected.len() && got.ct_eq(expected).into()
+}
+
 fn mac_psk_key_v3(psk: &[u8], domain: &str) -> [u8; 32] {
     let d = domain.as_bytes();
     let mut buf = Vec::with_capacity(4 + psk.len() + 4 + d.len());
@@ -274,6 +285,26 @@ mod tests {
         let (ack, s) = build_ack(psk, dom, &c).unwrap();
         let s2 = parse_ack(psk, dom, &ack, &c).unwrap();
         assert_eq!(s2, s);
+    }
+
+    #[test]
+    fn secret_eq_accepts_equal_and_rejects_everything_else() {
+        assert!(secret_eq("token-abc", "token-abc"));
+        assert!(secret_eq(&b"token-abc"[..], "token-abc"));
+        // Same length, different content.
+        assert!(!secret_eq("token-abc", "token-abd"));
+        assert!(!secret_eq("Token-abc", "token-abc"));
+        // Different lengths (prefix and suffix cases).
+        assert!(!secret_eq("token-ab", "token-abc"));
+        assert!(!secret_eq("token-abcd", "token-abc"));
+    }
+
+    #[test]
+    fn secret_eq_empty_inputs() {
+        assert!(secret_eq("", ""));
+        assert!(secret_eq(&b""[..], ""));
+        assert!(!secret_eq("", "token"));
+        assert!(!secret_eq("token", ""));
     }
 
     #[test]

--- a/bibavpn/src/incoming.rs
+++ b/bibavpn/src/incoming.rs
@@ -60,7 +60,7 @@ where
             WsHandshakeKind::NewPath
         } else if legacy_path_auth {
             let legacy = format!("/b/{token}");
-            if path == legacy.as_str() {
+            if crate::crypto_layer::secret_eq(path, legacy.as_str()) {
                 WsHandshakeKind::LegacyPath
             } else {
                 write_camouflage_status(&mut stream, 404, camouflage::NOT_FOUND_HTML).await?;

--- a/bibavpn/src/lib.rs
+++ b/bibavpn/src/lib.rs
@@ -38,6 +38,7 @@ pub mod udp_mux;
 pub mod ws_auth;
 pub mod ws_bridge;
 
+pub use crypto_layer::secret_eq;
 pub use frame::{
     read_padded_frame, read_padded_frame_borrow, read_padded_frame_into, write_padded_frame,
     write_padded_frame_with_mode, write_padded_frame_with_mode_state, AdaptivePadState, FrameError,

--- a/bibavpn/src/socks5.rs
+++ b/bibavpn/src/socks5.rs
@@ -6,6 +6,8 @@ use anyhow::{bail, Context};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
+use crate::crypto_layer::secret_eq;
+
 const SOCKS5_AUTH_NONE: u8 = 0;
 const SOCKS5_AUTH_USERPASS: u8 = 2;
 
@@ -42,6 +44,19 @@ async fn socks5_negotiate_method(local: &mut TcpStream, require_userpass: bool) 
     Ok(())
 }
 
+/// Both comparisons always run and are constant time, so a wrong username is not
+/// distinguishable from a wrong password by timing.
+fn socks5_userpass_ok(
+    uname: &[u8],
+    passwd: &[u8],
+    expected_user: &str,
+    expected_pass: &str,
+) -> bool {
+    let user_ok = secret_eq(uname, expected_user);
+    let pass_ok = secret_eq(passwd, expected_pass);
+    user_ok & pass_ok
+}
+
 async fn socks5_userpass_verify(
     local: &mut TcpStream,
     expected_user: &str,
@@ -63,7 +78,7 @@ async fn socks5_userpass_verify(
     let mut passwd = vec![0u8; plen];
     local.read_exact(&mut passwd).await.context("passwd")?;
 
-    let ok = uname == expected_user.as_bytes() && passwd == expected_pass.as_bytes();
+    let ok = socks5_userpass_ok(&uname, &passwd, expected_user, expected_pass);
     if ok {
         local.write_all(&[1u8, 0u8]).await.context("rfc1929 ok")?;
         Ok(())
@@ -237,8 +252,20 @@ pub fn is_benign_handshake_abort(err: &anyhow::Error) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_benign_handshake_abort;
+    use super::{is_benign_handshake_abort, socks5_userpass_ok};
     use anyhow::Context;
+
+    #[test]
+    fn userpass_ok_only_for_both_correct() {
+        assert!(socks5_userpass_ok(b"user", b"pass", "user", "pass"));
+        assert!(!socks5_userpass_ok(b"user", b"wrong", "user", "pass"));
+        assert!(!socks5_userpass_ok(b"wrong", b"pass", "user", "pass"));
+        assert!(!socks5_userpass_ok(b"wrong", b"wrong", "user", "pass"));
+        // Length mismatches (prefix of the expected value must not pass).
+        assert!(!socks5_userpass_ok(b"use", b"pass", "user", "pass"));
+        assert!(!socks5_userpass_ok(b"user", b"pas", "user", "pass"));
+        assert!(!socks5_userpass_ok(b"", b"", "user", "pass"));
+    }
 
     #[test]
     fn benign_abort_detects_version_eof() {

--- a/bibavpn/src/ws_auth.rs
+++ b/bibavpn/src/ws_auth.rs
@@ -8,6 +8,7 @@ use tokio::time::timeout;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::WebSocketStream;
 
+use crate::crypto_layer::secret_eq;
 use crate::protocol::{decode_auth, is_auth_frame};
 use crate::server_limits::{PreAuthBudget, PreAuthBudgetTracker};
 
@@ -36,7 +37,7 @@ where
                     }
                     if is_auth_frame(b.as_ref()) {
                         let tok = decode_auth(b.as_ref())?;
-                        if tok == expected_token {
+                        if secret_eq(tok.as_str(), expected_token) {
                             return Ok::<_, anyhow::Error>(());
                         }
                         anyhow::bail!("auth token mismatch");


### PR DESCRIPTION
## Проблема

Секреты сессии сравнивались обычными `==` / `!=`, то есть побайтово с ранним выходом, хотя остальной код на это внимание обращает. В репозитории уже есть два места, где сделано правильно, что и подчёркивает несогласованность:

- `crypto_layer::parse_ack`: `if tag.ct_ne(expected.as_slice()).into()` с комментарием «Constant-time compare: avoid leaking how many leading bytes matched»;
- `server_metrics::MetricsAuth::authorize`: `got.len() == expected.len() && got.ct_eq(expected).into()`.

## Что сделано

Один общий хелпер в `crypto_layer.rs` (там уже импортирован `subtle::ConstantTimeEq`), реэкспортирован из корня крейта рядом с существующими `pub use frame::{…}`:

```rust
pub fn secret_eq(got: impl AsRef<[u8]>, expected: impl AsRef<[u8]>) -> bool
```

`impl AsRef<[u8]>` принимает `&str`, `String`, `&[u8]`, `Vec<u8>` без шума на местах вызова. Doc-комментарий прямо говорит, что константно только сравнение содержимого, а длина по-прежнему наблюдаема и ничем не маскируется — вместо имитации сокрытия длины паддингом.

Исправленные места:

| Файл | Место | Было |
|---|---|---|
| `ws_auth.rs` | `server_wait_token_auth` | `tok == expected_token` |
| `bin/server.rs` | `server_wait_v3_auth` | `tok != expected_token` |
| `socks5.rs` | `socks5_userpass_verify` | `uname == … && passwd == …` |
| `incoming.rs` | `accept_websocket_or_camouflage` | `path == legacy.as_str()` |

Последнее — сверх изначального списка: в устаревшем режиме `--legacy-path-auth` сравнивался токен, встроенный в путь запроса. Однозначно сравнение секрета, правка в одну строку.

Оба AUTH-места сохранили ровно своё логирование (`warn!(target: "bibavpn_security", %peer_ip, …)`), тексты `anyhow::bail!`, вызовы `record_failure`/`record_success`, `inc_handshake_success()` и учёт `PreAuthBudgetTracker` — менялось только само выражение сравнения.

Для SOCKS-креденшлов добавлен предикат без короткого замыкания:

```rust
let user_ok = secret_eq(uname, expected_user);
let pass_ok = secret_eq(passwd, expected_pass);
user_ok & pass_ok
```

`&`, а не `&&`, и оба вызова в отдельных `let` — поэтому неверный логин по таймингу не отличается от неверного пароля. Асинхронный I/O-поток `socks5_userpass_verify` не тронут.

## Проверка

Тесты хелпера: равные секреты приняты, одинаковая длина с разным содержимым отклонена, разница в регистре отклонена, разные длины (короче и длиннее) отклонены, пустые входы ведут себя разумно. Тесты SOCKS-предиката: только оба верных дают `true`; неверный пароль, неверный логин, оба неверных, усечённый логин, усечённый пароль, оба пустых.

Локально workspace не собирается (на машине нет MSVC-линкера), сборку проверяет CI этого PR.

## Найдено, но намеренно не тронуто

- `reality.rs` `is_short_id_allowed` — `allowed.iter().any(|a| a == id)` по `[u8; 8]` плюс линейный проход, вызывается из `validate_short_id` до любого учёта rate-limit. Реальное сравнение под контролем атакующего, но этот файл сейчас правит PR про аутентификацию REALITY — сообщаю, не редактирую.
- `start_json_config.rs` — сравнение токена конфига с токеном инвайта, оба локальные для клиента, удалённого тайминг-канала нет.
- `reality.rs` `expected_mac != blake3::Hash::from(server_mac)` — у `blake3::Hash` реализация `PartialEq` документирована как константная, в коде уже есть комментарий об этом. Корректно как есть.
- Не секреты: сверка DER-пина сертификата, пиннинг **публичного** X25519-ключа, проверки тегов/версий/магиков протокола, сравнение непубличного WS-пути, корреляционные `xid` в udp_mux.
- В `apps/` (Rust/Tauri, Kotlin, Swift, JS) и в крейте `biba/` сравнений секретов нет вообще.

## Замечание

`ws_auth::server_wait_token_auth` не вызывается нигде в репозитории — это экспортированный, но мёртвый API. Исправлен всё равно, но стоит знать, что место не живое.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
