### PR TITLE
fix(reality): require client AUTH before the tunnel (was an open proxy)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ the client sends `MUX_OPEN`; per-target opens use mux records (stream id, flags,
 payload) inside padded frames, with window-based flow control. Use `--no-mux` for
 legacy **one WSS per SOCKS CONNECT** (`OPEN` + binary loop). **REALITY** mode uses
 the same `**--ws-parallel` 1..=4** pattern: each outer link runs TLS + WSS +
-REALITY (X25519) handshake, then `MUX_OPEN`; the pool **round-robins** new streams
+REALITY (X25519 + client AUTH) handshake, then `MUX_OPEN`; the pool **round-robins** new streams
 (`connect_reality_tcp_mux_handle` in `local_client.rs`).
 
 **UDP** (e.g. DNS via SOCKS5 UDP) uses a **separate** shared WSS:
@@ -96,12 +96,23 @@ for the operator story.
 
 **REALITY (WSS path):** optional front-domain mode — outer **TLS SNI** follows
 `reality_target` (e.g. `vk.com`), then **WSS upgrade**, then **X25519** binary frames on the
-WebSocket (`reality.rs`), then **plaintext** `MUX_OPEN` (no v3 PSK on that TCP path). This is
+WebSocket (`reality.rs`), then a **mandatory client AUTH frame**, then **plaintext** `MUX_OPEN`
+(no v3 PSK on that TCP path). This is
 **not** Xray-style TLS ClientHello stealing; see **[PROTOCOL.md — REALITY](PROTOCOL.md#reality-wss-path)**.
 Server: `--reality-target`, `--reality-private-key`, optional `--reality-short-ids` (SpiderX
-background fetch runs when REALITY is enabled). Client / invite: `reality_target`,
+background fetch runs when REALITY is enabled; a missing/all-zeros allowlist accepts any short ID and
+logs a `WARN` at startup). Client / invite: `reality_target`,
 `reality_public_key`, `reality_short_id`. Outer TLS may use **rustls** or **boring** (same as
 non-REALITY). Test: `cargo test -p bibavpn --test reality_handshake`.
+
+**REALITY client AUTH is required** in every REALITY session, on both the `MUX_OPEN` and the
+REALITY + v3 (UDP mux) sub-paths: `[version:1][0xa1][mac:32]` right after `SERVER_HELLO`, where the
+MAC is keyed BLAKE3 over `client_ephemeral_pub || server_pub` keyed by `shared_secret || token`
+(`reality_client_auth_mac`). The X25519 exchange only authenticates the **server**, so before this
+frame existed the REALITY TCP path was an **open proxy**. The token is never sent on the wire; the
+server compares in constant time and records failures with the auth rate limiter, like a v3 AUTH
+mismatch. Adding a frame does not change the HELLO / SERVER_HELLO layout, so `REALITY_VERSION`
+stays `2` — but old and new peers no longer interoperate on the REALITY path.
 
 Typical traffic path (TCP, mux):
 
@@ -155,7 +166,7 @@ Full layout for `**apps/`** (desktop, Android, JNI crate, scripts): **[apps/AGEN
 | `bibavpn/src/ws_auth.rs`                            | Server waits for sealed `AUTH` (timeout, pre-`AUTH` junk/decrypt budgets via `PreAuthBudget` in `server_limits.rs`)   |
 | `bibavpn/src/tcp_mux.rs`                            | Mux wire format, client handle, server bridge, optional idle dummy, multi-WSS pool + RR                            |
 | `bibavpn/src/tcp_mux_roadmap.rs`                    | **Historical** one-WSS mux sketch; **current** implementation is `tcp_mux.rs` (doc-only module)                    |
-| `bibavpn/src/reality.rs`                              | WSS REALITY: X25519 exchange, SpiderX, `effective_tls_sni`, invite fields                     |
+| `bibavpn/src/reality.rs`                              | WSS REALITY: X25519 exchange, mandatory client AUTH MAC (`reality_client_auth_mac`), SpiderX, `effective_tls_sni`, invite fields                     |
 | `bibavpn/src/client_tls_stream.rs`, `tls_boring.rs` | `TlsStack` paths: `rustls` (default) vs `boring` (`--features boring-tls`); REALITY + Boring; **`--pin-cert`** on both; Boring **`--tls-fragment`** via `SSL_CTX_set_max_send_fragment` |
 | `bibavpn/src/client_policy.rs`                      | TLS client label resolution: `fingerprint` → `tls_profile` → invite → `stealth` → default **Chrome 132+**          |
 | `bibavpn/src/stealth_v12.rs`                        | `StealthProfile` / presets (pad, jitter, decoys, idle threshold, server RTT defaults)                              |
@@ -214,7 +225,7 @@ the mux record header when chunking TCP).
 - `--early-ws-frames`, `--junk-frames`
 - `--pin-cert` (client) — incompatible with `--insecure`; supported on **rustls** and **boring** (`boring-tls` build)
 - `--reality-target`, `--reality-public-key`, `--reality-short-id` (client) — WSS REALITY front mode; invite JSON mirrors these fields
-- Server **REALITY:** `--reality-target vk.com:443`, `--reality-private-key` (base64 X25519 seed, 32 bytes), `--reality-short-ids` (hex, comma-separated; empty = any; all-zero entry = wildcard), `--reality-server-names` (optional SNI allowlist; default = host from target)
+- Server **REALITY:** `--reality-target vk.com:443`, `--reality-private-key` (base64 X25519 seed, 32 bytes), `--reality-short-ids` (hex, comma-separated; empty = any + startup `WARN`; all-zero entry = wildcard + startup `WARN`), `--reality-server-names` (optional SNI allowlist; default = host from target). `--token` is **required** on the REALITY path too: it keys the client AUTH MAC.
 - `--ws-path` / server `--ws-path` — WebSocket path; token via `AUTH`
 (default `/ws`)
 - Client `--proto` (only `**3`** is supported) and `--proto-domain` (KDF label;
@@ -466,7 +477,7 @@ This table tracks **PROTOCOL.md roadmap** items against what the **current tree*
 | **Padding**              | `PadMode::Adaptive` + `stealth` / presets                                                                                                                                | Future spec may redefine burst heuristics / budgets                                                                                      |
 | **Jitter**               | Min/max MS on WS sends; preset merge                                                                                                                                     | Spec band (e.g. 5–25 ms) as product default                                          |
 | **Decoys**               | Parallel `--decoy-gets` + idle decoys (`--idle-decoy-secs`): same **TLS/WS fingerprint class** as tunnel (UA / `Accept-Language` / upgrade shape); decoy fields in presets (`stealth_v12.rs`) | Full `--decoy-mode browser` catalog (Referer parity, etc.) per spec                     |
-| **REALITY (WSS)**        | X25519 after WSS upgrade; pinned server pubkey in invite; auto **SNI** from `reality_target`; plaintext mux; SpiderX; **rustls** or **boring** outer TLS; test `reality_handshake.rs` | Xray TLS ClientHello relay / uTLS parity on REALITY path |
+| **REALITY (WSS)**        | X25519 after WSS upgrade; pinned server pubkey in invite; **mandatory client AUTH MAC (token)** before any application frame; auto **SNI** from `reality_target`; plaintext mux; SpiderX; **rustls** or **boring** outer TLS; test `reality_handshake.rs` | Xray TLS ClientHello relay / uTLS parity on REALITY path |
 | **Desync**               | `DesyncConfig` on wire + `desync` module (`effective_desync_mode` / `DesyncApplied`; operator notes in PROTOCOL/README) | Raw-socket / OS hook paths; privilege guards                                         |
 | **UI / JNI**             | `start_json_config` fields for new options where wired                                                                                                                   | Expose all toggles in Tauri + Android as they stabilize                              |
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -256,8 +256,9 @@ Top to bottom: **from the app to bytes inside one tunnel frame**. The hop from t
 **Default TCP (multiplexed):** **one to four** **TLS + WSS** sessions per client
 process (round-robin assignment of new streams when `--ws-parallel` is 2–4); many
 SOCKS connections become **mux streams** on those sockets. The same **1..=4** count
-applies in **REALITY** mode: each session runs REALITY (X25519) then the mux phase
-(plaintext `MUX_OPEN` on the REALITY path — see `local_client` / `reality` modules).
+applies in **REALITY** mode: each session runs REALITY (X25519 + mandatory client
+**AUTH** MAC) then the mux phase (plaintext `MUX_OPEN` on the REALITY path — see
+`local_client` / `reality` modules).
 
 ```mermaid
 flowchart TB
@@ -351,8 +352,22 @@ on your VPS.
 1. Client → VPS: **TLS** (SNI = front domain from `reality_target`) + **WSS** upgrade on `--ws-path`.
 2. **REALITY binary exchange** on the WebSocket (before v3 PSK on this path):
    - Client → server: `[version:1][client_ephemeral_x25519:32][short_id:8]`
-   - Server → client: `[version:1][server_long_term_x25519:32]` (must match invite `reality_public_key`)
-3. Client sends plaintext **`MUX_OPEN`**; mux streams carry target TCP (no v3 HELLO/AUTH on this path).
+   - Server → client: `[version:1][server_long_term_x25519:32][confirm_mac:32]` — the pubkey must
+     match invite `reality_public_key`, and the MAC (keyed BLAKE3 over both pubkeys, keyed by the
+     X25519 shared secret) proves the server holds the private key.
+3. **Mandatory client AUTH** (`[version:1][0xa1][mac:32]`): keyed BLAKE3 over
+   `client_ephemeral_pub || server_pub`, keyed by `shared_secret || token`. The **token never goes on
+   the wire** and the MAC is bound to this handshake, so it cannot be replayed into another session.
+   The server compares in constant time and **drops the connection before any application frame** if
+   it does not match (counted by the auth rate limiter / ban list like a v3 AUTH failure).
+4. Client sends plaintext **`MUX_OPEN`**; mux streams carry target TCP (no v3 HELLO/AUTH on this path).
+
+Step 3 is **required in every REALITY session**, including the REALITY + v3 PSK (UDP mux) path where
+a v3 `HELLO` follows instead of `MUX_OPEN`. REALITY itself authenticates only the *server*; without
+this step anyone able to reach the port and complete the WSS upgrade would get full proxying (the
+short-ID allowlist is permissive by default — see `--reality-short-ids`). Adding the frame does not
+change the HELLO / SERVER_HELLO layout, so `REALITY_VERSION` stays **2**; older clients/servers fail
+the handshake immediately (breaking change on the REALITY path only).
 
 **Server CLI**
 
@@ -362,6 +377,10 @@ bibavpn-server \
   --reality-private-key "$REALITY_PRIV_B64" \
   --reality-short-ids '0123456789abcdef'   # optional; omit = any; 000…000 = wildcard
 ```
+
+Omitting `--reality-short-ids` (or listing `0000000000000000`) accepts **any** short ID; the server
+logs a `WARN` on `bibavpn_security` at startup. Clients still have to pass the REALITY AUTH frame
+with the right `--token`, so this is a fingerprinting/pinning weakness, not an open proxy.
 
 Generate keys in Rust (`RealityServerConfig::generate_keys()`), or from any X25519 tool; publish
 the **public** key and a **short ID** in the client invite. **SpiderX** (background GETs to the
@@ -374,12 +393,14 @@ target) starts automatically when REALITY is enabled — warms camouflage agains
 | `reality_target` | Front reference, e.g. `vk.com:443` — sets outer **SNI** unless `--sni` overrides |
 | `reality_public_key` | Base64, 32-byte X25519 public key (pin against MITM) |
 | `reality_short_id` | 16 hex digits (8 bytes); must match server allowlist when configured |
+| `token` | Session token — also keys the mandatory REALITY **AUTH** MAC (step 3) |
 
 **Build note:** outer TLS may use **`--tls-stack rustls`** (default) or **`boring`** (build with
 `--features boring-tls`). **`--pin-cert`** works on both. REALITY does **not** replace VPS IP
 allowlists — it aligns **SNI / handshake behaviour**, not routing to the front site's IP.
 
-**Tests:** `cargo test -p bibavpn --test reality_handshake` (WSS + X25519 roundtrip).
+**Tests:** `cargo test -p bibavpn --test reality_handshake` (WSS + X25519 roundtrip, forged server
+rejected, wrong/missing client AUTH rejected).
 
 ## Transport shaping knobs
 
@@ -441,7 +462,8 @@ exhaustive changelog):
 - **P0 TLS:** optional **BoringSSL** build (`boring-tls` + `--tls-stack boring`)
   for record-size control and production **`--pin-cert`** on the Boring path;
   **`rustls` remains the default** and does not provide full JA3 parity by itself.
-- **P0 REALITY (WSS):** X25519 exchange after WSS; pinned pubkey in invite; auto SNI from
+- **P0 REALITY (WSS):** X25519 exchange after WSS; pinned pubkey in invite; **mandatory client AUTH
+  MAC** (token, bound to the handshake) before any application frame; auto SNI from
   `reality_target`; integration test `reality_handshake.rs`. **Not** Xray TLS-hook REALITY.
 - **P0 RTT:** **delayed ACK** and **RTT mask jitter** on the server; **1–4 WSS** +
   **round-robin** in `tcp_mux` (v3 and REALITY both use the same pool pattern).

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ Every CLI flag is documented in **[AGENTS.md](AGENTS.md)**. Essentials:
 - **REALITY (optional):** server `--reality-target`, `--reality-private-key`;
   client/invite `reality_target`, `reality_public_key`, `reality_short_id`. The
   outer SNI then defaults to the front host (`vk.com:443` → SNI `vk.com`) while
-  TCP still connects to `--server`.
+  TCP still connects to `--server`. The client must also prove knowledge of
+  `--token` in a mandatory AUTH frame right after the REALITY exchange (a MAC —
+  the token itself never goes on the wire).
 
 Secrets never go in the URL: the token travels in the sealed AUTH frame, and
 the WebSocket path (`--ws-path`, default `/ws`) carries no credentials.

--- a/bibavpn/src/bin/server.rs
+++ b/bibavpn/src/bin/server.rs
@@ -532,6 +532,23 @@ async fn main() -> anyhow::Result<()> {
             short_ids.len()
         );
 
+        // `is_short_id_allowed` is permissive for an empty list or an all-zero
+        // entry: any short ID passes. Clients still have to pass the REALITY
+        // AUTH frame, but the operator should know the ID is not pinned.
+        let wildcard_short_id = short_ids.iter().any(|id| id.iter().all(|&b| b == 0));
+        if short_ids.is_empty() || wildcard_short_id {
+            let reason = if short_ids.is_empty() {
+                "empty allowlist"
+            } else {
+                "all-zeros wildcard entry"
+            };
+            warn!(
+                target: "bibavpn_security",
+                reason,
+                "REALITY short-ID allowlist accepts ANY short ID; pin clients with --reality-short-ids"
+            );
+        }
+
         Some(RealityServerConfig {
             private_key: privkey_arr,
             target: target.clone(),
@@ -1018,9 +1035,34 @@ async fn handle_one(
 
     if let Some(ref reality_cfg) = reality_config {
         info!("REALITY mode: app tunnel after X25519");
-        server_handshake_reality(&mut ws, reality_cfg)
-            .await
-            .context("REALITY handshake")?;
+        // REALITY authenticates only the server, so the client must prove it
+        // knows the session token (MAC bound to this handshake) *before* any
+        // application frame is honoured — otherwise this is an open proxy.
+        match timeout(
+            handshake_timeout,
+            server_handshake_reality(&mut ws, reality_cfg, &token),
+        )
+        .await
+        {
+            Ok(Ok(_session_key)) => {
+                auth.record_success(peer_ip).await;
+            }
+            Ok(Err(e)) => {
+                auth.record_failure(peer_ip).await;
+                warn!(
+                    target: "bibavpn_security",
+                    %peer_ip,
+                    session_id = params.session_id,
+                    "REALITY handshake/AUTH rejected: {e:#}"
+                );
+                return Err(e).context("REALITY handshake");
+            }
+            Err(_) => {
+                params.stats.inc_handshake_timeout();
+                auth.record_failure(peer_ip).await;
+                anyhow::bail!("handshake timeout waiting for REALITY AUTH");
+            }
+        }
 
         let domain_trim = proto_domain.trim();
         if domain_trim.is_empty() {
@@ -1033,6 +1075,7 @@ async fn handle_one(
 
         if is_v3_mux_open(next.as_ref()) {
             info!("REALITY: TCP mux (plaintext mux records)");
+            params.stats.inc_handshake_success();
             return bibavpn::tcp_mux::bridge_ws_tcp_mux_server(
                 ws,
                 max_pad,

--- a/bibavpn/src/lib.rs
+++ b/bibavpn/src/lib.rs
@@ -45,11 +45,15 @@ pub use frame::{
 };
 pub use invite_uri::{decode_invite_v1, encode_invite_v1, InviteV1};
 pub use reality::{
-    decode_server_hello, effective_tls_sni, encode_client_hello, extract_sni,
-    is_short_id_allowed, parse_target, create_tls_connector, reality_client_exchange_verify,
+    decode_client_auth, decode_server_hello, effective_tls_sni, encode_client_auth,
+    encode_client_hello, extract_sni,
+    is_short_id_allowed, parse_target, create_tls_connector, reality_client_auth_mac,
+    reality_client_exchange_verify,
     reality_confirm_mac, server_handshake_reality, server_hello_with_confirm,
+    server_hello_with_confirm_and_shared,
     RealityClientConfig, RealityServerConfig,
-    REALITY_MAGIC, REALITY_VERSION, spiderx_fetch, spawn_spiderx, TlsFingerprint,
+    REALITY_CLIENT_AUTH_LEN, REALITY_CLIENT_AUTH_TAG, REALITY_MAGIC, REALITY_VERSION,
+    spiderx_fetch, spawn_spiderx, TlsFingerprint,
 };
 pub use start_json_config::{
     local_client_options_from_json_str, local_client_options_from_json_str_with_binds,

--- a/bibavpn/src/local_client.rs
+++ b/bibavpn/src/local_client.rs
@@ -360,7 +360,8 @@ pub fn normalize_ws_path(s: &str) -> String {
     }
 }
 
-/// REALITY handshake: send client hello with public key + short ID, receive server hello
+/// REALITY handshake: client hello (public key + short ID), server hello, then
+/// the mandatory AUTH frame proving knowledge of `cfg.token`.
 async fn reality_client_handshake<S>(
     ws: &mut WebSocketStream<S>,
     cfg: &ClientCfg,
@@ -374,11 +375,15 @@ where
 
     let short_id = cfg.reality_short_id.unwrap_or_else(|| rand::random::<[u8; 8]>());
 
-    let session_key =
-        crate::reality::reality_client_exchange_verify(ws, &server_expected_pubkey, &short_id)
-            .await?;
+    let session_key = crate::reality::reality_client_exchange_verify(
+        ws,
+        &server_expected_pubkey,
+        &short_id,
+        &cfg.token,
+    )
+    .await?;
 
-    info!("REALITY handshake complete, session key derived, server verified");
+    info!("REALITY handshake complete, session key derived, server verified, AUTH sent");
 
     Ok((session_key, short_id))
 }

--- a/bibavpn/src/reality.rs
+++ b/bibavpn/src/reality.rs
@@ -6,7 +6,10 @@
 //! 1. Client opens TLS to the VPS with **SNI = front domain** (`reality_target`, e.g. `vk.com`).
 //! 2. Standard WSS upgrade on `--ws-path`.
 //! 3. Binary REALITY frames: X25519 ephemeral + short ID → server long-term pubkey (pinned in invite).
-//! 4. Plaintext mux (`MUX_OPEN`) or v3 PSK tunnel follows.
+//! 4. Mandatory client AUTH frame: MAC over the handshake transcript keyed by the
+//!    X25519 shared secret **and** the session token. Without it the REALITY path
+//!    would be an open proxy (the X25519 exchange only authenticates the server).
+//! 5. Plaintext mux (`MUX_OPEN`) or v3 PSK tunnel follows.
 //!
 //! SpiderX background fetches keep server-side camouflage warm against the REALITY target.
 
@@ -18,6 +21,7 @@ use futures_util::{SinkExt, StreamExt};
 use rand::Rng;
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::DigitallySignedStruct;
+use subtle::ConstantTimeEq;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio_rustls::client::TlsStream;
@@ -33,10 +37,23 @@ pub const REALITY_MAGIC: &[u8] = b"REAL1";
 /// server proves possession of the REALITY private key (v1 only echoed the
 /// pinned public key, which a MITM that knows it could trivially replay).
 /// v2 is intentionally incompatible with v1 on both ends.
+///
+/// The mandatory client AUTH frame is an **added** frame after SERVER_HELLO and
+/// does not change the HELLO / SERVER_HELLO layout, so the version stays at 2;
+/// a peer that omits or mis-frames it is rejected on the spot anyway.
 pub const REALITY_VERSION: u8 = 2;
 
 /// BLAKE3 derive-key context for the REALITY handshake confirmation MAC.
 const REALITY_CONFIRM_CONTEXT: &str = "bibavpn reality server-confirm v2";
+
+/// BLAKE3 derive-key context for the mandatory client AUTH MAC.
+const REALITY_CLIENT_AUTH_CONTEXT: &str = "bibavpn reality client-auth v1";
+
+/// Frame tag of the client AUTH frame (byte 1, after the version byte).
+pub const REALITY_CLIENT_AUTH_TAG: u8 = 0xa1;
+
+/// Wire size of the client AUTH frame: `[version][tag][mac:32]`.
+pub const REALITY_CLIENT_AUTH_LEN: usize = 1 + 1 + 32;
 
 /// Server confirmation MAC over the handshake transcript, keyed by the X25519
 /// shared secret. Only a peer holding the REALITY private key (server) or the
@@ -53,6 +70,59 @@ pub fn reality_confirm_mac(
     h.update(client_ephemeral_pub);
     h.update(server_static_pub);
     h.finalize()
+}
+
+/// Client AUTH MAC over the handshake transcript, keyed by the X25519 shared
+/// secret **and** the session token. The token never touches the wire, and the
+/// MAC is bound to both public keys, so it cannot be replayed into another
+/// session (different ephemeral key → different shared secret → different MAC).
+///
+/// The X25519 exchange alone only authenticates the *server*
+/// (see `reality_confirm_mac`); this MAC is what authenticates the *client*.
+pub fn reality_client_auth_mac(
+    shared: &[u8; 32],
+    token: &str,
+    client_ephemeral_pub: &[u8; 32],
+    server_static_pub: &[u8; 32],
+) -> [u8; 32] {
+    // Key material = shared secret || token. `shared` is fixed-width, so the
+    // concatenation is unambiguous. Knowing only one of the two is not enough.
+    let mut ikm = Vec::with_capacity(32 + token.len());
+    ikm.extend_from_slice(shared);
+    ikm.extend_from_slice(token.as_bytes());
+    let mac_key = blake3::derive_key(REALITY_CLIENT_AUTH_CONTEXT, &ikm);
+    let mut h = blake3::Hasher::new_keyed(&mac_key);
+    h.update(client_ephemeral_pub);
+    h.update(server_static_pub);
+    *h.finalize().as_bytes()
+}
+
+/// Wire bytes for the client AUTH frame: `[version][tag][mac:32]`.
+pub fn encode_client_auth(mac: &[u8; 32]) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(REALITY_CLIENT_AUTH_LEN);
+    msg.push(REALITY_VERSION);
+    msg.push(REALITY_CLIENT_AUTH_TAG);
+    msg.extend_from_slice(mac);
+    msg
+}
+
+/// Decode the client AUTH frame `[version][tag][mac:32]` into the MAC.
+pub fn decode_client_auth(data: &[u8]) -> anyhow::Result<[u8; 32]> {
+    if data.len() < REALITY_CLIENT_AUTH_LEN {
+        bail!("short REALITY client AUTH");
+    }
+    if data[0] != REALITY_VERSION {
+        bail!("unsupported REALITY version in client AUTH: {}", data[0]);
+    }
+    if data[1] != REALITY_CLIENT_AUTH_TAG {
+        bail!(
+            "expected REALITY client AUTH frame, got tag 0x{:02x}",
+            data[1]
+        );
+    }
+    let mut mac = [0u8; 32];
+    mac.copy_from_slice(&data[2..34]);
+    Ok(mac)
 }
 
 /// Max Ping/Pong frames tolerated during the REALITY handshake before the peer
@@ -215,6 +285,15 @@ pub fn server_hello_with_confirm(
     private_key: &[u8; 32],
     client_ephemeral_pub: &[u8; 32],
 ) -> anyhow::Result<Vec<u8>> {
+    server_hello_with_confirm_and_shared(private_key, client_ephemeral_pub).map(|(wire, _)| wire)
+}
+
+/// Same as `server_hello_with_confirm`, but also returns the X25519 shared
+/// secret so the caller can verify the client AUTH MAC that follows.
+pub fn server_hello_with_confirm_and_shared(
+    private_key: &[u8; 32],
+    client_ephemeral_pub: &[u8; 32],
+) -> anyhow::Result<(Vec<u8>, [u8; 32])> {
     let server_secret = StaticSecret::from(*private_key);
     let client_public = PublicKey::try_from(*client_ephemeral_pub)
         .map_err(|_| anyhow::anyhow!("invalid REALITY client public key"))?;
@@ -226,7 +305,7 @@ pub fn server_hello_with_confirm(
     response.push(REALITY_VERSION);
     response.extend_from_slice(&server_pub);
     response.extend_from_slice(mac.as_bytes());
-    Ok(response)
+    Ok((response, *shared.as_bytes()))
 }
 
 fn validate_short_id(short_id: &[u8; 8], cfg: &RealityServerConfig) -> anyhow::Result<()> {
@@ -239,59 +318,88 @@ fn validate_short_id(short_id: &[u8; 8], cfg: &RealityServerConfig) -> anyhow::R
     );
 }
 
-/// Server-side REALITY X25519 exchange: validate client HELLO, reply with pinned pubkey from `cfg.private_key`.
+/// Next binary frame during a REALITY handshake, answering Ping and skipping
+/// Pong within `MAX_HANDSHAKE_CONTROL_FRAMES`. `what` names the expected frame
+/// in error messages; `control_frames` is the budget shared by all handshake
+/// phases so a pre-auth peer cannot reset it by advancing a phase.
+async fn next_handshake_binary<S>(
+    ws: &mut WebSocketStream<S>,
+    control_frames: &mut u32,
+    what: &str,
+) -> anyhow::Result<Bytes>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send,
+{
+    loop {
+        match ws.next().await {
+            Some(Ok(Message::Binary(b))) => return Ok(b),
+            Some(Ok(Message::Ping(p))) => {
+                *control_frames += 1;
+                if *control_frames > MAX_HANDSHAKE_CONTROL_FRAMES {
+                    bail!("too many control frames during REALITY handshake");
+                }
+                ws.send(Message::Pong(p)).await.context("REALITY pong")?;
+            }
+            Some(Ok(Message::Pong(_))) => {
+                *control_frames += 1;
+                if *control_frames > MAX_HANDSHAKE_CONTROL_FRAMES {
+                    bail!("too many control frames during REALITY handshake");
+                }
+            }
+            Some(Ok(_)) => bail!("expected binary {what}"),
+            Some(Err(e)) => Err(e).context("websocket recv")?,
+            None => bail!("ws closed before {what}"),
+        }
+    }
+}
+
+/// Server-side REALITY handshake: validate client HELLO, reply with the pinned
+/// pubkey from `cfg.private_key`, then **require** a client AUTH frame proving
+/// knowledge of `token`. Returns the X25519 shared secret on success.
+///
+/// The AUTH step is mandatory: REALITY only authenticates the server, so without
+/// it any peer that completes the WebSocket upgrade would get a working tunnel
+/// (the short-id allowlist is permissive by default, see `is_short_id_allowed`).
 pub async fn server_handshake_reality<S>(
     ws: &mut WebSocketStream<S>,
     cfg: &RealityServerConfig,
-) -> anyhow::Result<()>
+    token: &str,
+) -> anyhow::Result<[u8; 32]>
 where
     S: AsyncRead + AsyncWrite + Unpin + Send,
 {
     let mut control_frames: u32 = 0;
-    loop {
-        let msg = match ws.next().await {
-            Some(Ok(Message::Binary(b))) => b,
-            Some(Ok(Message::Ping(p))) => {
-                control_frames += 1;
-                if control_frames > MAX_HANDSHAKE_CONTROL_FRAMES {
-                    bail!("too many control frames during REALITY handshake");
-                }
-                ws.send(Message::Pong(p)).await.context("REALITY pong")?;
-                continue;
-            }
-            Some(Ok(Message::Pong(_))) => {
-                control_frames += 1;
-                if control_frames > MAX_HANDSHAKE_CONTROL_FRAMES {
-                    bail!("too many control frames during REALITY handshake");
-                }
-                continue;
-            }
-            Some(Ok(_)) => bail!("expected binary REALITY HELLO"),
-            Some(Err(e)) => Err(e).context("websocket recv")?,
-            None => bail!("ws closed before REALITY HELLO"),
-        };
+    let msg = next_handshake_binary(ws, &mut control_frames, "REALITY HELLO").await?;
 
-        if msg.len() < 1 + 32 + 8 {
-            bail!("short REALITY HELLO");
-        }
-        if msg[0] != REALITY_VERSION {
-            bail!("unsupported REALITY version: {}", msg[0]);
-        }
-
-        let client_pubkey: [u8; 32] = msg[1..33].try_into().unwrap();
-        let mut short_id = [0u8; 8];
-        short_id.copy_from_slice(&msg[33..41]);
-
-        validate_short_id(&short_id, cfg)?;
-
-        // Reply with the pinned pubkey plus a MAC proving we hold the private
-        // key (binds the X25519 shared secret to the transcript).
-        let response = server_hello_with_confirm(&cfg.private_key, &client_pubkey)?;
-        ws.send(Message::Binary(Bytes::from(response)))
-            .await
-            .context("send REALITY SERVER_HELLO")?;
-        return Ok(());
+    if msg.len() < 1 + 32 + 8 {
+        bail!("short REALITY HELLO");
     }
+    if msg[0] != REALITY_VERSION {
+        bail!("unsupported REALITY version: {}", msg[0]);
+    }
+
+    let client_pubkey: [u8; 32] = msg[1..33].try_into().unwrap();
+    let mut short_id = [0u8; 8];
+    short_id.copy_from_slice(&msg[33..41]);
+
+    validate_short_id(&short_id, cfg)?;
+
+    // Reply with the pinned pubkey plus a MAC proving we hold the private
+    // key (binds the X25519 shared secret to the transcript).
+    let (response, shared) =
+        server_hello_with_confirm_and_shared(&cfg.private_key, &client_pubkey)?;
+    ws.send(Message::Binary(Bytes::from(response)))
+        .await
+        .context("send REALITY SERVER_HELLO")?;
+
+    let server_pub = RealityServerConfig::public_key_from_private(&cfg.private_key);
+    let auth = next_handshake_binary(ws, &mut control_frames, "REALITY client AUTH").await?;
+    let got = decode_client_auth(auth.as_ref())?;
+    let expected = reality_client_auth_mac(&shared, token, &client_pubkey, &server_pub);
+    if !bool::from(got[..].ct_eq(&expected[..])) {
+        bail!("REALITY: client AUTH MAC invalid (unknown token)");
+    }
+    Ok(shared)
 }
 
 /// REALITY client connection (standalone helper; main client uses `reality_client_exchange_verify`).
@@ -354,11 +462,13 @@ pub fn encode_client_hello(short_id: &[u8; 8], client_pubkey: &[u8; 32]) -> Vec<
     msg
 }
 
-/// Client REALITY HELLO + verify server pubkey (X25519 ephemeral).
+/// Client REALITY HELLO + verify server pubkey (X25519 ephemeral), then send the
+/// mandatory AUTH frame proving knowledge of `token`. Returns the session key.
 pub async fn reality_client_exchange_verify<S>(
     ws: &mut WebSocketStream<S>,
     expected_server_pubkey: &[u8; 32],
     short_id: &[u8; 8],
+    token: &str,
 ) -> anyhow::Result<[u8; 32]>
 where
     S: AsyncRead + AsyncWrite + Unpin + Send,
@@ -371,53 +481,43 @@ where
         .context("send REALITY client hello")?;
 
     let mut control_frames: u32 = 0;
-    loop {
-        let msg = match ws.next().await {
-            Some(Ok(Message::Binary(b))) => b,
-            Some(Ok(Message::Ping(p))) => {
-                control_frames += 1;
-                if control_frames > MAX_HANDSHAKE_CONTROL_FRAMES {
-                    bail!("too many control frames during REALITY handshake");
-                }
-                ws.send(Message::Pong(p))
-                    .await
-                    .context("REALITY client pong")?;
-                continue;
-            }
-            Some(Ok(Message::Pong(_))) => {
-                control_frames += 1;
-                if control_frames > MAX_HANDSHAKE_CONTROL_FRAMES {
-                    bail!("too many control frames during REALITY handshake");
-                }
-                continue;
-            }
-            Some(Ok(_)) => bail!("expected binary server hello"),
-            Some(Err(e)) => Err(e).context("websocket recv")?,
-            None => bail!("server closed during REALITY handshake"),
-        };
-        let (server_pubkey, server_mac) = decode_server_hello(&msg)?;
-        if server_pubkey != *expected_server_pubkey {
-            bail!("REALITY: server public key mismatch (possible MITM)");
-        }
-        let server_public = PublicKey::from(server_pubkey);
-        let shared_secret = ephemeral_secret.diffie_hellman(&server_public);
+    let msg = next_handshake_binary(ws, &mut control_frames, "server hello").await?;
 
-        // Verify the server proved possession of the private key. A MITM that
-        // only knows the pinned public key cannot derive the shared secret and
-        // thus cannot forge this MAC. `blake3::Hash` compares in constant time.
-        let expected_mac = reality_confirm_mac(
-            shared_secret.as_bytes(),
-            ephemeral_public.as_bytes(),
-            &server_pubkey,
-        );
-        if expected_mac != blake3::Hash::from(server_mac) {
-            bail!("REALITY: server confirmation MAC invalid (server lacks the private key; possible MITM)");
-        }
-
-        let mut session_key = [0u8; 32];
-        session_key.copy_from_slice(shared_secret.as_bytes());
-        return Ok(session_key);
+    let (server_pubkey, server_mac) = decode_server_hello(&msg)?;
+    if server_pubkey != *expected_server_pubkey {
+        bail!("REALITY: server public key mismatch (possible MITM)");
     }
+    let server_public = PublicKey::from(server_pubkey);
+    let shared_secret = ephemeral_secret.diffie_hellman(&server_public);
+
+    // Verify the server proved possession of the private key. A MITM that
+    // only knows the pinned public key cannot derive the shared secret and
+    // thus cannot forge this MAC. `blake3::Hash` compares in constant time.
+    let expected_mac = reality_confirm_mac(
+        shared_secret.as_bytes(),
+        ephemeral_public.as_bytes(),
+        &server_pubkey,
+    );
+    if expected_mac != blake3::Hash::from(server_mac) {
+        bail!("REALITY: server confirmation MAC invalid (server lacks the private key; possible MITM)");
+    }
+
+    let mut session_key = [0u8; 32];
+    session_key.copy_from_slice(shared_secret.as_bytes());
+
+    // Prove we know the session token (bound to this handshake transcript).
+    // The server drops the connection before any application frame otherwise.
+    let auth_mac = reality_client_auth_mac(
+        &session_key,
+        token,
+        ephemeral_public.as_bytes(),
+        &server_pubkey,
+    );
+    ws.send(Message::Binary(Bytes::from(encode_client_auth(&auth_mac))))
+        .await
+        .context("send REALITY client AUTH")?;
+
+    Ok(session_key)
 }
 
 /// Decode REALITY SERVER_HELLO `[version][pubkey:32][confirm_mac:32]`.
@@ -636,6 +736,98 @@ mod tests {
             reality_confirm_mac(client_shared.as_bytes(), client_public.as_bytes(), &real_pub);
 
         assert_ne!(expected_mac, forged_mac);
+    }
+
+    /// The client AUTH MAC is reproducible by both sides from the shared secret
+    /// plus the token, and the token itself never appears on the wire.
+    #[test]
+    fn client_auth_mac_matches_for_same_token() {
+        let (priv_key, server_pub) = RealityServerConfig::generate_keys();
+        let client_secret = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
+        let client_public = PublicKey::from(&client_secret);
+
+        let (_hello, server_shared) =
+            server_hello_with_confirm_and_shared(&priv_key, client_public.as_bytes()).unwrap();
+        let client_shared = client_secret.diffie_hellman(&PublicKey::from(server_pub));
+        assert_eq!(&server_shared, client_shared.as_bytes());
+
+        let sent = reality_client_auth_mac(
+            client_shared.as_bytes(),
+            "s3cret-token",
+            client_public.as_bytes(),
+            &server_pub,
+        );
+        let expected = reality_client_auth_mac(
+            &server_shared,
+            "s3cret-token",
+            client_public.as_bytes(),
+            &server_pub,
+        );
+        assert_eq!(sent, expected);
+
+        let wire = encode_client_auth(&sent);
+        let token_bytes = b"s3cret-token";
+        assert!(!wire
+            .windows(token_bytes.len())
+            .any(|w| w == &token_bytes[..]));
+        assert_eq!(decode_client_auth(&wire).unwrap(), expected);
+    }
+
+    #[test]
+    fn client_auth_mac_rejects_wrong_token() {
+        let (priv_key, server_pub) = RealityServerConfig::generate_keys();
+        let client_secret = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
+        let client_public = PublicKey::from(&client_secret);
+        let (_hello, shared) =
+            server_hello_with_confirm_and_shared(&priv_key, client_public.as_bytes()).unwrap();
+
+        let forged =
+            reality_client_auth_mac(&shared, "guessed", client_public.as_bytes(), &server_pub);
+        let expected =
+            reality_client_auth_mac(&shared, "real-token", client_public.as_bytes(), &server_pub);
+        assert_ne!(forged, expected);
+    }
+
+    /// Replaying a captured AUTH frame into another session fails: the MAC is
+    /// keyed by that session's X25519 shared secret.
+    #[test]
+    fn client_auth_mac_rejects_other_session_key() {
+        let (priv_key, server_pub) = RealityServerConfig::generate_keys();
+        let token = "real-token";
+
+        let first_client = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
+        let first_pub = PublicKey::from(&first_client);
+        let (_h1, first_shared) =
+            server_hello_with_confirm_and_shared(&priv_key, first_pub.as_bytes()).unwrap();
+        let captured =
+            reality_client_auth_mac(&first_shared, token, first_pub.as_bytes(), &server_pub);
+
+        let second_client = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
+        let second_pub = PublicKey::from(&second_client);
+        let (_h2, second_shared) =
+            server_hello_with_confirm_and_shared(&priv_key, second_pub.as_bytes()).unwrap();
+        let expected =
+            reality_client_auth_mac(&second_shared, token, second_pub.as_bytes(), &server_pub);
+
+        assert_ne!(captured, expected);
+    }
+
+    #[test]
+    fn client_auth_wire_layout() {
+        let mac = [5u8; 32];
+        let wire = encode_client_auth(&mac);
+        assert_eq!(wire.len(), REALITY_CLIENT_AUTH_LEN);
+        assert_eq!(wire[0], REALITY_VERSION);
+        assert_eq!(wire[1], REALITY_CLIENT_AUTH_TAG);
+        assert_eq!(decode_client_auth(&wire).unwrap(), mac);
+
+        assert!(decode_client_auth(&wire[..33]).is_err());
+        let mut bad_tag = wire.clone();
+        bad_tag[1] = 0x00;
+        assert!(decode_client_auth(&bad_tag).is_err());
+        let mut bad_ver = wire.clone();
+        bad_ver[0] = REALITY_VERSION.wrapping_add(1);
+        assert!(decode_client_auth(&bad_ver).is_err());
     }
 
     #[test]

--- a/bibavpn/src/udp_mux.rs
+++ b/bibavpn/src/udp_mux.rs
@@ -408,7 +408,7 @@ async fn connect_udp_mux_ws(
         let short_id = cfg
             .reality_short_id
             .unwrap_or_else(|| rand::random::<[u8; 8]>());
-        crate::reality::reality_client_exchange_verify(&mut ws, &pk, &short_id)
+        crate::reality::reality_client_exchange_verify(&mut ws, &pk, &short_id, &cfg.token)
             .await
             .context("REALITY handshake (udp mux)")?;
     }

--- a/bibavpn/tests/reality_handshake.rs
+++ b/bibavpn/tests/reality_handshake.rs
@@ -1,4 +1,5 @@
-//! REALITY X25519 exchange over a live TLS + WebSocket server (no full mux).
+//! REALITY X25519 exchange + mandatory client AUTH over a live TLS + WebSocket
+//! server (no full mux).
 
 use bibavpn::incoming::{accept_websocket_or_camouflage, CamouflageServeConfig};
 use bibavpn::reality::{
@@ -8,81 +9,73 @@ use bibavpn::stealth::{build_websocket_request, WsHandshakeParams};
 use bibavpn::tls_util::{install_ring_crypto, server_self_signed, TlsClientProfile};
 use futures_util::{SinkExt, StreamExt};
 use rustls::pki_types::ServerName;
+use std::net::SocketAddr;
 use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
 use tokio_rustls::TlsAcceptor;
-use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::client_async;
+use tokio_tungstenite::tungstenite::Message;
 
-#[tokio::test]
-async fn reality_handshake_over_wss() {
-    install_ring_crypto();
-
-    let (priv_key, pub_key) = RealityServerConfig::generate_keys();
-    let short_id = {
-        let tmp = RealityServerConfig {
-            target: "front.example:443".into(),
-            server_names: vec!["front.example".into()],
-            private_key: priv_key,
-            short_ids: vec![],
-            min_client_ver: None,
-            max_client_ver: None,
-            max_time_diff: 0,
-        };
-        tmp.generate_short_id()
-    };
-
-    let reality_cfg = RealityServerConfig {
+fn reality_cfg_for(priv_key: [u8; 32], short_ids: Vec<[u8; 8]>) -> RealityServerConfig {
+    RealityServerConfig {
         target: "front.example:443".into(),
         server_names: vec!["front.example".into()],
         private_key: priv_key,
-        short_ids: vec![short_id],
+        short_ids,
         min_client_ver: None,
         max_client_ver: None,
         max_time_diff: 0,
-    };
+    }
+}
 
+/// Accept one TLS + WSS connection and run the server side of the REALITY
+/// handshake (including AUTH verification against `token`).
+async fn spawn_reality_server(
+    cfg: RealityServerConfig,
+    ws_path: &str,
+    token: &str,
+) -> (SocketAddr, JoinHandle<anyhow::Result<[u8; 32]>>) {
     let tls_cfg = server_self_signed("127.0.0.1").expect("self-signed");
     let acceptor = TlsAcceptor::from(tls_cfg);
-
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
     let addr = listener.local_addr().expect("addr");
-    let ws_path = "/ws".to_string();
-    let token = "test-token".to_string();
 
-    let server_cfg = reality_cfg.clone();
-    let ws_path_s = ws_path.clone();
-    let token_s = token.clone();
-    tokio::spawn(async move {
+    let ws_path = ws_path.to_string();
+    let token = token.to_string();
+    let handle = tokio::spawn(async move {
         let (tcp, _) = listener.accept().await.expect("accept");
         let tls = acceptor.accept(tcp).await.expect("tls accept");
         let (mut ws, _) = accept_websocket_or_camouflage(
             tls,
-            &ws_path_s,
+            &ws_path,
             false,
-            &token_s,
+            &token,
             CamouflageServeConfig::default(),
             None,
         )
         .await
         .expect("ws")
         .expect("ws some");
-        server_handshake_reality(&mut ws, &server_cfg)
-            .await
-            .expect("server REALITY");
+        let res = server_handshake_reality(&mut ws, &cfg, &token).await;
         let _ = ws.close(None).await;
+        res
     });
+    (addr, handle)
+}
 
+async fn client_ws(
+    addr: SocketAddr,
+    ws_path: &str,
+) -> tokio_tungstenite::WebSocketStream<tokio_rustls::client::TlsStream<tokio::net::TcpStream>> {
     let tcp = tokio::net::TcpStream::connect(addr).await.expect("connect");
-    let connector = tokio_rustls::TlsConnector::from(
-        bibavpn::tls_util::client_config_insecure(),
-    );
+    let connector = tokio_rustls::TlsConnector::from(bibavpn::tls_util::client_config_insecure());
     let sn = ServerName::try_from("127.0.0.1".to_string()).unwrap();
     let tls = connector.connect(sn, tcp).await.expect("client tls");
 
     let req = build_websocket_request(WsHandshakeParams {
         host_for_tcp: "127.0.0.1",
         port: addr.port(),
-        path: &ws_path,
+        path: ws_path,
         sni: "127.0.0.1",
         host_header: None,
         origin: None,
@@ -91,12 +84,99 @@ async fn reality_handshake_over_wss() {
         extra_headers: &[],
         tls_profile: TlsClientProfile::Default,
     });
-    let (mut ws, _) = client_async(req, tls).await.expect("ws client");
+    let (ws, _) = client_async(req, tls).await.expect("ws client");
+    ws
+}
 
-    let session_key = reality_client_exchange_verify(&mut ws, &pub_key, &short_id)
+#[tokio::test]
+async fn reality_handshake_over_wss() {
+    install_ring_crypto();
+
+    let (priv_key, pub_key) = RealityServerConfig::generate_keys();
+    let short_id = reality_cfg_for(priv_key, vec![]).generate_short_id();
+    let token = "test-token";
+
+    let (addr, server) =
+        spawn_reality_server(reality_cfg_for(priv_key, vec![short_id]), "/ws", token).await;
+    let mut ws = client_ws(addr, "/ws").await;
+
+    let session_key = reality_client_exchange_verify(&mut ws, &pub_key, &short_id, token)
         .await
         .expect("client REALITY");
     assert_eq!(session_key.len(), 32);
+
+    let server_shared = server
+        .await
+        .expect("join")
+        .expect("server REALITY (correct token must be accepted)");
+    assert_eq!(server_shared, session_key);
+    let _ = ws.close(None).await;
+}
+
+/// A client that completes the X25519 exchange but does not know the session
+/// token must be rejected before any application frame: the REALITY path would
+/// otherwise be an open proxy.
+#[tokio::test]
+async fn reality_handshake_rejects_wrong_token() {
+    install_ring_crypto();
+
+    let (priv_key, pub_key) = RealityServerConfig::generate_keys();
+    let short_id = [0u8; 8];
+
+    let (addr, server) = spawn_reality_server(
+        reality_cfg_for(priv_key, vec![short_id]),
+        "/ws",
+        "right-token",
+    )
+    .await;
+    let mut ws = client_ws(addr, "/ws").await;
+
+    // The server is authentic, so the client side of the exchange succeeds; the
+    // AUTH frame it sends is keyed by the wrong token.
+    let _ = reality_client_exchange_verify(&mut ws, &pub_key, &short_id, "wrong-token").await;
+
+    let res = server.await.expect("join");
+    assert!(
+        res.is_err(),
+        "server must reject a client AUTH with a wrong token"
+    );
+    let _ = ws.close(None).await;
+}
+
+/// A client that skips the AUTH frame and jumps straight to an application
+/// frame (the pre-fix behaviour: plaintext `MUX_OPEN`) must be rejected.
+#[tokio::test]
+async fn reality_handshake_rejects_missing_auth() {
+    install_ring_crypto();
+
+    let (priv_key, _pub_key) = RealityServerConfig::generate_keys();
+    let short_id = [0u8; 8];
+
+    let (addr, server) = spawn_reality_server(
+        reality_cfg_for(priv_key, vec![short_id]),
+        "/ws",
+        "test-token",
+    )
+    .await;
+    let mut ws = client_ws(addr, "/ws").await;
+
+    // Raw HELLO, no AUTH: send a plaintext MUX_OPEN instead.
+    let mut hello = vec![REALITY_VERSION];
+    hello.extend_from_slice(&[7u8; 32]);
+    hello.extend_from_slice(&short_id);
+    ws.send(Message::Binary(hello.into())).await.expect("hello");
+    let _server_hello = ws.next().await;
+    ws.send(Message::Binary(
+        bibavpn::protocol::encode_v3_mux_open().into(),
+    ))
+    .await
+    .expect("mux open");
+
+    let res = server.await.expect("join");
+    assert!(
+        res.is_err(),
+        "server must reject an application frame in place of REALITY AUTH"
+    );
     let _ = ws.close(None).await;
 }
 
@@ -145,27 +225,9 @@ async fn reality_handshake_rejects_forged_server() {
         let _ = ws.close(None).await;
     });
 
-    let tcp = tokio::net::TcpStream::connect(addr).await.expect("connect");
-    let connector =
-        tokio_rustls::TlsConnector::from(bibavpn::tls_util::client_config_insecure());
-    let sn = ServerName::try_from("127.0.0.1".to_string()).unwrap();
-    let tls = connector.connect(sn, tcp).await.expect("client tls");
+    let mut ws = client_ws(addr, &ws_path).await;
 
-    let req = build_websocket_request(WsHandshakeParams {
-        host_for_tcp: "127.0.0.1",
-        port: addr.port(),
-        path: &ws_path,
-        sni: "127.0.0.1",
-        host_header: None,
-        origin: None,
-        user_agent: None,
-        accept_language: None,
-        extra_headers: &[],
-        tls_profile: TlsClientProfile::Default,
-    });
-    let (mut ws, _) = client_async(req, tls).await.expect("ws client");
-
-    let res = reality_client_exchange_verify(&mut ws, &pub_key, &short_id).await;
+    let res = reality_client_exchange_verify(&mut ws, &pub_key, &short_id, &token).await;
     assert!(res.is_err(), "client must reject a forged confirmation MAC");
     let _ = ws.close(None).await;
 }


### PR DESCRIPTION
## Проблема: в REALITY-режиме туннель был открытым прокси

`handle_one` в REALITY-ветке выполнял `server_handshake_reality`, читал следующий бинарный фрейм и при `is_v3_mux_open(next)` уходил прямо в `bridge_ws_tcp_mux_server(ws, …, None /* crypto */, …)`. Токен сессии на этом пути **не проверялся вообще** — `server_wait_v3_auth` вызывался только на под-пути v3 HELLO / UDP-mux.

Единственным барьером оставался REALITY short id, но `is_short_id_allowed` возвращает `true` при пустом allowlist (это дефолт) и при любой записи из одних нулей. Сам обмен X25519 аутентифицирует только **сервер** (`reality_confirm_mac` доказывает владение приватным ключом); клиента не аутентифицирует ничто.

Итого: кто угодно, дотянувшийся до порта, мог сделать WSS-upgrade на известном `--ws-path`, послать REALITY HELLO и затем `MUX_OPEN` — и получить полный TCP-прокси через VPS оператора. Клиент в `connect_reality_tcp_mux_handle_attempts` работал ровно так же, то есть это был штатный путь, а не экзотика.

## Изменение протокола (только REALITY-путь)

После `SERVER_HELLO` клиент **обязан** прислать новый фрейм `[version:1][0xa1][mac:32]`.

MAC — keyed BLAKE3 по `client_ephemeral_pub || server_pub`, ключ выведен как `derive_key("bibavpn reality client-auth v1", shared_secret || token)`. Токен на провод не попадает; знание только shared secret или только токена не даёт MAC. Сервер проверяет фрейм через `subtle::ConstantTimeEq` **до** чтения любого прикладного фрейма, то есть покрыты оба под-пути — и `MUX_OPEN`, и v3 HELLO / UDP-mux.

`REALITY_VERSION` остаётся **2**: раскладка HELLO / SERVER_HELLO не менялась, добавлен только новый фрейм, а несовместимые старый/новый пиры и так падают сразу (старый клиент присылает `MUX_OPEN` → не проходит `decode_client_auth`; новый клиент присылает AUTH → старый сервер ждёт mux open или v3 HELLO).

**Это ломающее изменение: сервер и клиент REALITY-режима надо обновлять вместе.**

## Что ещё сделано

- Ping/Pong-бюджет `MAX_HANDSHAKE_CONTROL_FRAMES` вынесен в общий `next_handshake_binary` и теперь **разделяется всеми фазами** хендшейка, иначе пир сбрасывал бы счётчик, просто перейдя к следующей фазе.
- Подписи `server_handshake_reality` / `reality_client_exchange_verify` изменены (а не добавлены новые функции), чтобы ни один вызывающий не смог случайно остаться на неаутентифицированном варианте.
- Отказ AUTH учитывается как остальные провалы авторизации: `auth.record_failure(peer_ip)` + `warn!` в `bibavpn_security`; таймаут дополнительно инкрементирует `stats.inc_handshake_timeout()`; успех — `auth.record_success(peer_ip)`.
- На старте сервера пишется `warn!`, если REALITY включён с пустым allowlist short id или с нулевым wildcard — поведение остаётся разрешающим, но оператор об этом узнаёт.
- `stats.inc_handshake_success()` теперь инкрементируется на `MUX_OPEN`-пути, где раньше не считалось ничего. На REALITY + v3 пути намеренно не вызывается, чтобы не считать дважды (там это делает `server_wait_v3_auth`).

## Проверка

`bibavpn/tests/reality_handshake.rs` переработан на общие хелперы `spawn_reality_server` / `client_ws`: верный токен принят (и shared secret у клиента и сервера совпадают), неверный токен отклонён, **отсутствие AUTH отклонено** (сырой HELLO, затем plaintext `MUX_OPEN` — ровно та атака, что работала до этого патча), плюс существующий тест про подделку сервера. Ещё 4 юнит-теста в `reality.rs`.

Локально workspace не собирается (на машине нет MSVC-линкера), сборку проверяет CI этого PR.

## Известное ограничение: свежести от сервера нет

MAC покрывает `client_ephemeral_pub || server_pub`, а `server_pub` — статичный ключ сервера. В транскрипте нет ни серверного nonce, ни другой свежести со стороны сервера, поэтому **записанный AUTH-фрейм воспроизводим**: достаточно повторить тот же HELLO (публичный ключ клиента, приватный не нужен) и приложить захваченный MAC.

Практическая планка такого повтора — доступ к **плейнтексту** прошлого хендшейка, то есть компрометация TLS-слоя (терминирующий middlebox, дамп памяти, логирующий прокси перед сервером). Пассивный сетевой наблюдатель фреймы не видит, а подставной сервер не получит AUTH, потому что клиент сначала проверяет серверный confirm-MAC, который требует приватного ключа. То есть открытый прокси закрыт, но replay-стойкость этот патч не даёт.

Правильное продолжение — добавить серверный nonce в `SERVER_HELLO` и включить его в MAC; это меняет раскладку `SERVER_HELLO` и требует `REALITY_VERSION = 3`, поэтому оставлено отдельным PR, а не смешано с закрытием дыры.

## Вне области этого PR

Серверный `--token` по умолчанию равен `"change-me"` и не проверяется на непустоту. Клиентские junk-фреймы `send_noise_binaries` (udp_mux), если включены, всё ещё будут восприняты как «первый прикладной фрейм» после REALITY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
