### PR TITLE
ci: run cargo test on push and pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,94 @@
+# Manual: Actions → Tests → Run workflow. Also runs on push/PR when Rust sources change.
+#
+# The build workflows compile the crates but never `cargo test`, and `cargo build`
+# does not even type-check `#[cfg(test)]` code — so unit tests could break (or fail
+# to compile) unnoticed. Each job runs the tests on the platform where that crate is
+# already known to build: core crates on Linux (same as the Docker images),
+# bibavpn-desktop on Windows (same as Desktop Windows).
+name: Tests
+
+run-name: Tests · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
+
+on:
+  workflow_dispatch:
+
+  workflow_call:
+
+  push:
+    branches: [main, master]
+    paths:
+      - "bibavpn/**"
+      - "!bibavpn/**/*.md"
+      - "biba/**"
+      - "!biba/**/*.md"
+      - "apps/bibavpn-desktop/**"
+      - "!apps/bibavpn-desktop/**/*.md"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/test.yml"
+  pull_request:
+    branches: [main, master]
+    paths:
+      - "bibavpn/**"
+      - "!bibavpn/**/*.md"
+      - "biba/**"
+      - "!biba/**/*.md"
+      - "apps/bibavpn-desktop/**"
+      - "!apps/bibavpn-desktop/**/*.md"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/test.yml"
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  core:
+    name: cargo test (bibavpn, biba)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      # Covers the library, both binaries (bibavpn-server / bibavpn-client) and
+      # the integration tests under bibavpn/tests.
+      - name: cargo test -p bibavpn -p biba
+        run: cargo test -p bibavpn -p biba --locked
+
+  desktop:
+    name: cargo test (bibavpn-desktop)
+    runs-on: windows-latest
+    timeout-minutes: 60
+    env:
+      BIBA_BYPASS_DOMAINS_URL: ${{ secrets.BIBA_BYPASS_DOMAINS_URL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: apps/bibavpn-desktop/ui/package-lock.json
+
+      # tauri-build needs the frontend dist to exist, same as the Desktop Windows build.
+      - name: Install UI deps & build frontend
+        working-directory: apps/bibavpn-desktop/ui
+        run: npm install --no-audit --no-fund && npm run build
+
+      - name: cargo test -p bibavpn-desktop
+        run: cargo test -p bibavpn-desktop --locked


### PR DESCRIPTION
## Проблема

Ни один workflow не запускает `cargo test`:

```
$ grep -rn "cargo test\|cargo clippy\|cargo fmt" .github/workflows/
(пусто)
```

Сборочные workflow (Android, Desktop Windows/macOS, iOS, Docker) компилируют крейты, но `cargo build` **не проверяет типы в коде под `#[cfg(test)]`**. То есть юнит-тесты могут не только сломаться, но и перестать компилироваться, и ни один workflow этого не заметит — ошибка всплывёт только у того, кто первым запустит `cargo test` локально.

Покрытие сборками сейчас такое: библиотека компилируется во всех workflow, `bin/bibavpn-server` и `bin/bibavpn-client` — в docker-джобах (`cargo build --release -p bibavpn --bin …`), тестовый код — нигде.

## Что сделано

Два джоба, каждый на той платформе, где соответствующий крейт уже заведомо собирается:

- **`core`** — `cargo test -p bibavpn -p biba --locked` на `ubuntu-latest` (та же платформа, что у docker-образов). Покрывает библиотеку, оба бинарника и интеграционные тесты в `bibavpn/tests` (они чистые проверки формата, без сети и без внешних сервисов).
- **`desktop`** — `cargo test -p bibavpn-desktop --locked` на `windows-latest`, повторяя Desktop Windows, включая сборку фронтенда, которую требует `tauri-build`.

Фильтры путей, `concurrency`, кэш `Swatinem/rust-cache`, `dtolnay/rust-toolchain@stable` и стиль заголовка — как в существующих workflow. Добавлен `workflow_call`, чтобы джобы можно было переиспользовать из релизного пайплайна.

`bibavpn-jni` и `bibavpn-ffi` намеренно не включены: это cdylib/staticlib под Android/iOS, host-тестируемой логики в них нет, а сборка под чужой таргет только добавила бы хрупкости.

## Замечание про уже открытые PR

Для `pull_request` в том же репозитории GitHub берёт файл workflow из **head-ветки** PR. Поэтому мердж этого PR не проверит тесты в уже открытых ветках автоматически — они начнут прогоняться после того, как каждая ветка будет перебазирована на `main` (что им и так предстоит из-за пересечений по `bin/server.rs`, `incoming.rs` и десктопному `lib.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
