### PR TITLE
fix(desktop): keep retrying tunnel recovery after wake (fixes #69)

### DIFF
--- a/apps/bibavpn-desktop/src-tauri/src/lib.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/lib.rs
@@ -101,6 +101,11 @@ pub(crate) struct Inner {
     tunnel_server: Option<String>,
     last_error: Option<String>,
     phase: VpnPhase,
+    /// The watchdog tore the tunnel down (sleep / network change) and has not got
+    /// it back yet. The system proxy is deliberately left in place (fail-closed),
+    /// so the watchdog must keep retrying instead of giving up after one attempt.
+    /// Cleared by a successful connect or an explicit user disconnect.
+    recovery_pending: bool,
 }
 
 #[derive(Clone)]
@@ -411,24 +416,98 @@ fn tunnel_is_healthy(http_port: u16) -> bool {
 }
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
+/// Backoff for repeated recovery attempts: 2s → 5s → 10s → 20s → 30s (capped),
+/// on top of the watchdog's own 12 s tick.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn next_recovery_backoff(current: Duration) -> Duration {
+    let next = match current.as_secs() {
+        0 => 2,
+        s if s < 5 => 5,
+        s if s < 10 => 10,
+        s if s < 20 => 20,
+        _ => 30,
+    };
+    Duration::from_secs(next)
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn spawn_tunnel_recovery_watch(app: AppHandle, state: AppState) {
-    std::thread::spawn(move || loop {
+    std::thread::spawn(move || {
+        let mut retry_backoff = Duration::from_secs(0);
+        loop {
         let tick_started = Instant::now();
         std::thread::sleep(Duration::from_secs(12));
         let slept = tick_started.elapsed();
         let likely_wake = slept > Duration::from_secs(20);
 
-        let Some((http_port, client_dead)) = (|| {
+        // Two cases matter: a live session to health-check, and a recovery that
+        // has not succeeded yet. The latter used to be dropped entirely — after a
+        // failed post-wake reconnect the phase is Idle, so the watchdog skipped
+        // every later tick and never tried again, leaving the system proxy
+        // pointing at a local port with nothing behind it (no traffic at all).
+        enum Tick {
+            Check { http_port: u16, client_dead: bool },
+            Retry,
+        }
+        let tick = {
             let g = match state.inner.lock() {
                 Ok(g) => g,
                 Err(p) => p.into_inner(),
             };
-            if g.phase != VpnPhase::Connected {
-                return None;
+            match g.phase {
+                VpnPhase::Connected => g.vpn.as_ref().map(|vpn| Tick::Check {
+                    http_port: g.cfg.local_http_port,
+                    client_dead: vpn.join.is_finished(),
+                }),
+                VpnPhase::Idle if g.recovery_pending => Some(Tick::Retry),
+                _ => None,
             }
-            let vpn = g.vpn.as_ref()?;
-            Some((g.cfg.local_http_port, vpn.join.is_finished()))
-        })() else {
+        };
+        let Some(tick) = tick else {
+            retry_backoff = Duration::from_secs(0);
+            continue;
+        };
+
+        if let Tick::Retry = tick {
+            // Keep trying to restore the tunnel; the proxy stays applied
+            // (fail-closed) so nothing leaks around the VPN meanwhile.
+            if retry_backoff > Duration::from_secs(0) {
+                std::thread::sleep(retry_backoff);
+            }
+            match connect_inner(&state, &app) {
+                Ok(()) => {
+                    retry_backoff = Duration::from_secs(0);
+                    info!(
+                        target: "bibavpn_desktop",
+                        "туннель восстановлен после сна/смены сети"
+                    );
+                }
+                Err(e) => {
+                    retry_backoff = next_recovery_backoff(retry_backoff);
+                    warn!(
+                        target: "bibavpn_desktop",
+                        backoff_secs = retry_backoff.as_secs(),
+                        "автовосстановление VPN не удалось: {e}"
+                    );
+                    let mut g = match state.inner.lock() {
+                        Ok(g) => g,
+                        Err(p) => p.into_inner(),
+                    };
+                    g.last_error =
+                        Some(format!("Нет связи с сервером, переподключение… ({e})"));
+                    let snap = snapshot(&app, &g);
+                    drop(g);
+                    let _ = app.emit("vpn-state", &snap);
+                }
+            }
+            continue;
+        }
+
+        let Tick::Check {
+            http_port,
+            client_dead,
+        } = tick
+        else {
             continue;
         };
         if client_dead {
@@ -456,18 +535,34 @@ fn spawn_tunnel_recovery_watch(app: AppHandle, state: AppState) {
                 continue;
             }
         }
-        disconnect_inner(&state, &app, false);
-        if let Err(e) = connect_inner(&state, &app) {
-            warn!(target: "bibavpn_desktop", "автовосстановление VPN: {e}");
+        // Mark the recovery *before* tearing the tunnel down: if the reconnect
+        // below fails, later ticks must keep retrying (the system proxy stays
+        // applied, so without a retry the user is left with no traffic at all).
+        {
             let mut g = match state.inner.lock() {
                 Ok(g) => g,
                 Err(p) => p.into_inner(),
             };
-            g.last_error = Some(format!("После сна: {e}"));
+            g.recovery_pending = true;
+        }
+        disconnect_inner(&state, &app, false);
+        if let Err(e) = connect_inner(&state, &app) {
+            retry_backoff = next_recovery_backoff(retry_backoff);
+            warn!(
+                target: "bibavpn_desktop",
+                backoff_secs = retry_backoff.as_secs(),
+                "автовосстановление VPN: {e}"
+            );
+            let mut g = match state.inner.lock() {
+                Ok(g) => g,
+                Err(p) => p.into_inner(),
+            };
+            g.last_error = Some(format!("Нет связи с сервером, переподключение… ({e})"));
             let snap = snapshot(&app, &g);
             drop(g);
             let _ = app.emit("vpn-state", &snap);
         } else {
+            retry_backoff = Duration::from_secs(0);
             let g = match state.inner.lock() {
                 Ok(g) => g,
                 Err(p) => p.into_inner(),
@@ -475,6 +570,7 @@ fn spawn_tunnel_recovery_watch(app: AppHandle, state: AppState) {
             let snap = snapshot(&app, &g);
             drop(g);
             let _ = app.emit("vpn-state", &snap);
+        }
         }
     });
 }
@@ -618,6 +714,12 @@ fn disconnect_inner(state: &AppState, app: &AppHandle, restore_system_proxy: boo
             info!(target: "bibavpn_desktop", "отключение VPN");
             g.last_error = None;
             g.tunnel_server = None;
+            if restore_system_proxy {
+                // Явное отключение пользователем: авто-восстановление отменяется,
+                // иначе watchdog будет драться с пользователем и поднимать туннель
+                // обратно.
+                g.recovery_pending = false;
+            }
             // Снимок настроек забираем только если его собираются восстанавливать:
             // при restore_system_proxy == false (watchdog после сна) он должен
             // остаться в состоянии для повторного подключения.
@@ -772,6 +874,32 @@ impl Drop for ConnectingPhaseGuard {
 }
 
 #[cfg(all(test, not(any(target_os = "android", target_os = "ios"))))]
+mod recovery_backoff_tests {
+    use super::next_recovery_backoff;
+    use std::time::Duration;
+
+    #[test]
+    fn backoff_grows_then_caps() {
+        let mut d = Duration::from_secs(0);
+        let mut seen = Vec::new();
+        for _ in 0..6 {
+            d = next_recovery_backoff(d);
+            seen.push(d.as_secs());
+        }
+        assert_eq!(seen, vec![2, 5, 10, 20, 30, 30], "must ramp up and cap");
+    }
+
+    #[test]
+    fn backoff_resets_from_zero() {
+        assert_eq!(
+            next_recovery_backoff(Duration::from_secs(0)).as_secs(),
+            2,
+            "a fresh recovery starts at the shortest delay"
+        );
+    }
+}
+
+#[cfg(all(test, not(any(target_os = "android", target_os = "ios"))))]
 mod connecting_phase_guard_tests {
     use super::{ConnectingPhaseGuard, Inner, SavedConfig, VpnPhase};
     use std::sync::{Arc, Mutex};
@@ -784,6 +912,7 @@ mod connecting_phase_guard_tests {
             tunnel_server: None,
             last_error: None,
             phase,
+            recovery_pending: false,
         }))
     }
 
@@ -1019,6 +1148,8 @@ fn connect_inner(state: &AppState, app: &AppHandle) -> Result<(), String> {
     });
     g.tunnel_server = Some(remote_label);
     g.phase = VpnPhase::Connected;
+    // Туннель снова живой: авто-восстановление завершено.
+    g.recovery_pending = false;
     // Фаза доведена до Connected — сбрасывать в Idle на выходе больше не нужно.
     phase_guard.disarm();
     sync_tray_tooltip_i18n(app, true, &g.cfg);
@@ -1448,6 +1579,7 @@ pub fn run() -> anyhow::Result<()> {
             tunnel_server: None,
             last_error: None,
             phase: VpnPhase::Idle,
+            recovery_pending: false,
         })),
     };
 

--- a/apps/bibavpn-desktop/src-tauri/src/proxy_mac.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/proxy_mac.rs
@@ -30,13 +30,41 @@ pub fn init_process_limits() {
     }
 }
 
+/// `networksetup` can wedge indefinitely (right after wake, while the network
+/// service is in flux). It is called dozens of times per connect/disconnect, so a
+/// single stuck invocation would block the caller forever — bound it.
+const NETSETUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
 fn run_netsetup(args: &[&str]) -> Result<String, String> {
-    let out = Command::new(NETSETUP)
+    let mut child = Command::new(NETSETUP)
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
+        .spawn()
+        .map_err(|e| format!("networksetup: {e}"))?;
+    let deadline = std::time::Instant::now() + NETSETUP_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(format!(
+                        "{} {:?}: не ответил за {} с (зависание системной утилиты)",
+                        NETSETUP,
+                        args,
+                        NETSETUP_TIMEOUT.as_secs()
+                    ));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(e) => return Err(format!("networksetup: {e}")),
+        }
+    }
+    let out = child
+        .wait_with_output()
         .map_err(|e| format!("networksetup: {e}"))?;
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);


### PR DESCRIPTION
Fixes #69 — on macOS the app keeps the UI alive but passes **no traffic** after sleep / Wi-Fi change until the user toggles Connect/Disconnect by hand.

## Root cause
The watchdog tears the tunnel down with `disconnect_inner(.., restore_system_proxy = false)` — the system proxy deliberately stays pointed at the local port (fail-closed) — then immediately calls `connect_inner`. Right after wake the network usually isn't up, so that one attempt fails, `ConnectingPhaseGuard` sets the phase back to `Idle`, and every later tick bailed out on `phase != Connected`. So the proxy pointed at a local port with nothing behind it and **nothing ever retried**.

macOS is hit hardest because its network returns more slowly after wake, so the single attempt reliably lands in the "network not ready" window.

## Changes
- **`recovery_pending` in the shared state** — set before the watchdog tears the tunnel down; cleared on a successful connect or an **explicit user disconnect**, so the watchdog never fights the user.
- **Retry on later ticks** while a recovery is pending, with a capped backoff (2 → 5 → 10 → 20 → 30 s) on top of the 12 s tick, and a `"переподключение…"` message in `last_error` so the UI shows what is happening. The proxy stays applied throughout — **fail-closed**, nothing leaks around the VPN (the chosen behaviour).
- **`networksetup` timeout (15 s) + kill on expiry** in `proxy_mac.rs`. It is called dozens of times per connect/disconnect (5+ per network service × all services) and can wedge indefinitely while a service is in flux, blocking the caller forever. This was a latent hang, independent of the bug above.

## Tests
`recovery_backoff_tests` covers the ramp and the cap. `cargo test -p bibavpn-desktop` → green (12 tests) on Windows.

⚠️ `proxy_mac.rs` is `#[cfg(target_os = "macos")]`, so it is **not** compiled by a Windows/Linux build — the macOS CI job on this PR is the real check for it (same class of gap that broke the Android build in #52).

## Follow-up (not in this PR)
Real wake detection (NSWorkspace `didWake`) instead of the "slept > 20 s" heuristic — tracked in #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
