### PR TITLE
feat(desktop): Linux system proxy + CI-embed split-tunnel list

### DIFF
--- a/.github/scripts/ci-fetch-bypass-domains.sh
+++ b/.github/scripts/ci-fetch-bypass-domains.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Fetch split-tunnel / bypass-domains JSON for compile-time embedding.
+# Used by desktop + Android CI. Requires curl; uses python3 when available to validate.
+#
+# Env:
+#   BIBA_BYPASS_DOMAINS_URL — control-plane URL (repo secret). If unset, writes an empty payload.
+#   BIBA_BYPASS_DOMAINS_OUT — optional output path (default: apps/bibavpn-desktop/src-tauri/embedded/bypass_domains.json)
+#   BIBA_BYPASS_DOMAINS_REQUIRED — if "1"/"true", fail when URL is missing or fetch fails (release builds).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+OUT="${BIBA_BYPASS_DOMAINS_OUT:-$ROOT/apps/bibavpn-desktop/src-tauri/embedded/bypass_domains.json}"
+REQUIRED="${BIBA_BYPASS_DOMAINS_REQUIRED:-0}"
+URL="${BIBA_BYPASS_DOMAINS_URL:-}"
+EMPTY_JSON='{"version":1,"ttl_sec":86400,"presets":[]}'
+
+mkdir -p "$(dirname "$OUT")"
+
+is_required() {
+  case "$(printf '%s' "$REQUIRED" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+write_empty() {
+  printf '%s\n' "$EMPTY_JSON" >"$OUT"
+  echo "ci-fetch-bypass-domains: wrote empty embedded list → $OUT"
+}
+
+validate_json() {
+  local path="$1"
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$path" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path, encoding="utf-8") as f:
+    data = json.load(f)
+presets = data.get("presets")
+if not isinstance(presets, list):
+    raise SystemExit("bypass-domains JSON: missing presets[]")
+if len(presets) == 0:
+    raise SystemExit("bypass-domains JSON: presets[] is empty")
+n_dom = sum(len(p.get("domains") or []) for p in presets if isinstance(p, dict))
+print(f"ok: {len(presets)} presets, {n_dom} domains")
+PY
+  else
+    # Minimal check without python
+    grep -q '"presets"' "$path"
+  fi
+}
+
+if [ -z "$URL" ]; then
+  if is_required; then
+    echo "::error::BIBA_BYPASS_DOMAINS_URL secret is required but not set" >&2
+    exit 1
+  fi
+  write_empty
+  exit 0
+fi
+
+TMP="${OUT}.tmp"
+echo "ci-fetch-bypass-domains: GET $URL"
+if ! curl -fsSL --max-time 90 -A "bibavpn-ci/1.0" "$URL" -o "$TMP"; then
+  echo "::error::Failed to fetch BIBA_BYPASS_DOMAINS_URL" >&2
+  rm -f "$TMP"
+  if is_required; then
+    exit 1
+  fi
+  write_empty
+  exit 0
+fi
+
+if ! validate_json "$TMP"; then
+  echo "::error::Fetched bypass-domains payload failed validation" >&2
+  head -c 400 "$TMP" >&2 || true
+  echo >&2
+  rm -f "$TMP"
+  if is_required; then
+    exit 1
+  fi
+  write_empty
+  exit 0
+fi
+
+mv "$TMP" "$OUT"
+echo "ci-fetch-bypass-domains: embedded → $OUT ($(wc -c <"$OUT") bytes)"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -100,6 +100,11 @@ jobs:
           npm ci
           npm ci --prefix ./ui
 
+      - name: Fetch split-tunnel list for compile-time embed
+        env:
+          BIBA_BYPASS_DOMAINS_REQUIRED: ${{ github.event_name == 'workflow_call' && '1' || '0' }}
+        run: bash .github/scripts/ci-fetch-bypass-domains.sh
+
       - name: Initialize Tauri Android project
         run: |
           bash apps/scripts/tauri-android-init-local.sh

--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -1,7 +1,7 @@
-# Manual: Actions → Desktop Windows → Run workflow. Also runs on push/PR when core VPN library or desktop app paths change.
-name: Desktop Windows
+# Manual: Actions → Desktop Linux → Run workflow. Also runs on push/PR when core VPN library or desktop app paths change.
+name: Desktop Linux
 
-run-name: Desktop Windows · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
+run-name: Desktop Linux · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
 
 on:
   workflow_dispatch:
@@ -23,7 +23,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"
-      - ".github/workflows/desktop-windows.yml"
+      - ".github/workflows/desktop-linux.yml"
       - ".github/scripts/ci-fetch-bypass-domains.sh"
   pull_request:
     branches: [main, master]
@@ -37,21 +37,29 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"
-      - ".github/workflows/desktop-windows.yml"
+      - ".github/workflows/desktop-linux.yml"
       - ".github/scripts/ci-fetch-bypass-domains.sh"
 
 concurrency:
-  group: desktop-windows-${{ github.ref }}
+  group: desktop-linux-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
       BIBA_BYPASS_DOMAINS_URL: ${{ secrets.BIBA_BYPASS_DOMAINS_URL }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install system deps (Tauri / WebKitGTK)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq \
+            libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
+            patchelf libssl-dev build-essential pkg-config \
+            libayatana-appindicator3-dev
 
       - name: Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -70,7 +78,6 @@ jobs:
         run: npm install --no-audit --no-fund && npm run build
 
       - name: Fetch split-tunnel list for compile-time embed
-        shell: bash
         env:
           BIBA_BYPASS_DOMAINS_REQUIRED: ${{ github.event_name == 'workflow_call' && '1' || '0' }}
         run: bash .github/scripts/ci-fetch-bypass-domains.sh
@@ -78,13 +85,15 @@ jobs:
       - name: Build bibavpn-desktop (release)
         run: cargo build -p bibavpn-desktop --release
 
-      - name: Pack ZIP
-        shell: pwsh
-        run: Compress-Archive -Path target/release/bibavpn-desktop.exe -DestinationPath BibaVPN-windows-x64.zip -Force
+      - name: Pack tarball
+        run: |
+          set -euo pipefail
+          install -m 755 target/release/bibavpn-desktop BibaVPN-linux-x64
+          tar -czf BibaVPN-linux-x64.tar.gz BibaVPN-linux-x64
 
-      - name: Upload ZIP
+      - name: Upload tarball
         uses: actions/upload-artifact@v4
         with:
-          name: BibaVPN-windows-x64
-          path: BibaVPN-windows-x64.zip
+          name: BibaVPN-linux-x64
+          path: BibaVPN-linux-x64.tar.gz
           if-no-files-found: error

--- a/.github/workflows/desktop-macos.yml
+++ b/.github/workflows/desktop-macos.yml
@@ -24,6 +24,7 @@ on:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/desktop-macos.yml"
+      - ".github/scripts/ci-fetch-bypass-domains.sh"
   pull_request:
     branches: [main, master]
     paths:
@@ -37,6 +38,7 @@ on:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/desktop-macos.yml"
+      - ".github/scripts/ci-fetch-bypass-domains.sh"
 
 concurrency:
   group: desktop-macos-${{ github.ref }}
@@ -66,6 +68,11 @@ jobs:
       - name: Install UI deps & build frontend
         working-directory: apps/bibavpn-desktop/ui
         run: npm install --no-audit --no-fund && npm run build
+
+      - name: Fetch split-tunnel list for compile-time embed
+        env:
+          BIBA_BYPASS_DOMAINS_REQUIRED: ${{ github.event_name == 'workflow_call' && '1' || '0' }}
+        run: bash .github/scripts/ci-fetch-bypass-domains.sh
 
       - name: Build bibavpn-desktop (release)
         run: cargo build -p bibavpn-desktop --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,16 @@ jobs:
     uses: ./.github/workflows/desktop-windows.yml
     secrets: inherit
 
+  linux:
+    uses: ./.github/workflows/desktop-linux.yml
+    secrets: inherit
+
   android:
     uses: ./.github/workflows/android.yml
     secrets: inherit
 
   publish:
-    needs: [macos, windows, android]
+    needs: [macos, windows, linux, android]
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifacts
@@ -99,4 +103,5 @@ jobs:
           files: |
             dist/BibaVPN-macos-aarch64.dmg
             dist/BibaVPN-windows-x64.zip
+            dist/BibaVPN-linux-x64.tar.gz
             dist/BibaVPN-android-debug.apk

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,10 @@ apps/bibavpn-desktop/src-tauri/ios-bibavpn-extras/BibaVpnTunnel/rust-static/**/*
 /apps/bibavpn-desktop/node_modules
 apps/bibavpn-desktop/.merge-no-vite.json
 
+# CI-fetched split-tunnel list (baked at build time; secret URL)
+/apps/bibavpn-desktop/src-tauri/embedded/bypass_domains.json
+/apps/bibavpn-desktop/src-tauri/embedded/bypass_domains.json.tmp
+
 # Tauri `android init` output + merged VPN glue (regenerate: `npm run android:bootstrap` in apps/bibavpn-desktop)
 /apps/bibavpn-desktop/src-tauri/gen/
 

--- a/apps/bibavpn-desktop/src-tauri/build.rs
+++ b/apps/bibavpn-desktop/src-tauri/build.rs
@@ -1,10 +1,13 @@
-//! Подхватывает `BIBA_BYPASS_DOMAINS_URL` из окружения или `.env` (локально, не коммитится).
+//! Подхватывает `BIBA_BYPASS_DOMAINS_URL` из окружения или `.env` (локально, не коммитится)
+//! и вшивает JSON split-tunnel списка (`embedded/bypass_domains.json` или CI fetch).
 
-use std::path::PathBuf;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 fn env_file_candidates() -> Vec<PathBuf> {
     let mut out = Vec::new();
-    if let Ok(manifest) = std::env::var("CARGO_MANIFEST_DIR") {
+    if let Ok(manifest) = env::var("CARGO_MANIFEST_DIR") {
         let manifest = PathBuf::from(manifest);
         out.push(manifest.join(".env"));
         if let Some(parent) = manifest.parent() {
@@ -19,7 +22,7 @@ fn env_file_candidates() -> Vec<PathBuf> {
 
 fn load_dotenv() {
     for path in env_file_candidates() {
-        let Ok(text) = std::fs::read_to_string(&path) else {
+        let Ok(text) = fs::read_to_string(&path) else {
             continue;
         };
         for line in text.lines() {
@@ -31,7 +34,7 @@ fn load_dotenv() {
                 continue;
             };
             let key = key.trim();
-            if key.is_empty() || std::env::var(key).is_ok() {
+            if key.is_empty() || env::var(key).is_ok() {
                 continue;
             }
             let mut val = val.trim().to_string();
@@ -42,16 +45,81 @@ fn load_dotenv() {
             }
             // SAFETY: build.rs runs single-threaded before compilation.
             unsafe {
-                std::env::set_var(key, val);
+                env::set_var(key, val);
             }
         }
         break;
     }
 }
 
+fn empty_bypass_json() -> &'static str {
+    r#"{"version":1,"ttl_sec":86400,"presets":[]}"#
+}
+
+fn resolve_bypass_json_source(manifest: &Path) -> PathBuf {
+    if let Ok(p) = env::var("BIBA_BYPASS_DOMAINS_JSON_FILE") {
+        let path = PathBuf::from(p.trim());
+        if path.is_file() {
+            return path;
+        }
+    }
+    let embedded = manifest.join("embedded").join("bypass_domains.json");
+    if embedded.is_file() {
+        return embedded;
+    }
+    // Placeholder next to build.rs so local builds without CI fetch still compile.
+    let placeholder = manifest.join("embedded").join("bypass_domains.empty.json");
+    if placeholder.is_file() {
+        return placeholder;
+    }
+    embedded
+}
+
+fn embed_bypass_domains_json() {
+    let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"));
+    let dest = out_dir.join("bypass_domains_embedded.json");
+
+    let src = resolve_bypass_json_source(&manifest);
+    let body = if src.is_file() {
+        fs::read_to_string(&src).unwrap_or_else(|_| empty_bypass_json().to_string())
+    } else {
+        empty_bypass_json().to_string()
+    };
+    fs::write(&dest, body.as_bytes()).expect("write bypass_domains_embedded.json");
+
+    // Non-empty presets → runtime can treat embed as a configured source.
+    let has_presets = body
+        .find("\"presets\"")
+        .and_then(|i| body[i..].find('['))
+        .map(|bracket_rel| {
+            // bracket_rel is offset within the `"presets"` slice; recompute absolute.
+            let abs = body.find("\"presets\"").unwrap() + bracket_rel;
+            body[abs + 1..].trim_start().starts_with('{')
+        })
+        .unwrap_or(false);
+    if has_presets {
+        println!("cargo:rustc-env=BIBA_BYPASS_DOMAINS_EMBEDDED=1");
+    }
+
+    println!("cargo:rerun-if-changed={}", src.display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        manifest.join("embedded").join("bypass_domains.json").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        manifest
+            .join("embedded")
+            .join("bypass_domains.empty.json")
+            .display()
+    );
+    println!("cargo:rerun-if-env-changed=BIBA_BYPASS_DOMAINS_JSON_FILE");
+}
+
 fn main() {
     load_dotenv();
-    if let Ok(url) = std::env::var("BIBA_BYPASS_DOMAINS_URL") {
+    if let Ok(url) = env::var("BIBA_BYPASS_DOMAINS_URL") {
         let trimmed = url.trim();
         if !trimmed.is_empty() {
             println!("cargo:rustc-env=BIBA_BYPASS_DOMAINS_URL={trimmed}");
@@ -61,5 +129,6 @@ fn main() {
     for path in env_file_candidates() {
         println!("cargo:rerun-if-changed={}", path.display());
     }
+    embed_bypass_domains_json();
     tauri_build::build();
 }

--- a/apps/bibavpn-desktop/src-tauri/embedded/README.md
+++ b/apps/bibavpn-desktop/src-tauri/embedded/README.md
@@ -1,0 +1,11 @@
+# Embedded split-tunnel / bypass-domains list
+
+CI runs [`.github/scripts/ci-fetch-bypass-domains.sh`](../../../../.github/scripts/ci-fetch-bypass-domains.sh)
+before building desktop / Android clients. That script downloads the JSON from the
+`BIBA_BYPASS_DOMAINS_URL` repository secret into `bypass_domains.json` (gitignored).
+
+`build.rs` copies that file (or `bypass_domains.empty.json` as a fallback) into
+`OUT_DIR` so `bypass_domains.rs` can `include_str!` it at compile time.
+
+Local builds without the secret still compile; split-tunnel presets stay empty until
+runtime fetch succeeds.

--- a/apps/bibavpn-desktop/src-tauri/embedded/bypass_domains.empty.json
+++ b/apps/bibavpn-desktop/src-tauri/embedded/bypass_domains.empty.json
@@ -1,0 +1,1 @@
+{"version":1,"ttl_sec":86400,"presets":[]}

--- a/apps/bibavpn-desktop/src-tauri/src/bypass_domains.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/bypass_domains.rs
@@ -1,7 +1,9 @@
 //! Bypass (split-tunnel) domain lists from the control-plane API.
 //!
 //! URL is **not** hardcoded: set `BIBA_BYPASS_DOMAINS_URL` at build time (CI secret / local `.env`)
-//! or at runtime. Responses are cached on disk under `%LOCALAPPDATA%/BibaVPN/`.
+//! or at runtime. CI also fetches the JSON before `cargo build` and embeds it via `build.rs`
+//! (`include_str!` from `OUT_DIR`) so split-tunnel works offline / before the first refresh.
+//! Responses are cached on disk under the platform data dir (`…/BibaVPN/`).
 
 use std::collections::HashMap;
 use std::fs;
@@ -149,6 +151,25 @@ pub fn bypass_domains_url() -> Option<String> {
             Some(t.to_string())
         }
     })
+}
+
+/// JSON baked in at compile time (CI `ci-fetch-bypass-domains.sh` → `build.rs` → OUT_DIR).
+const EMBEDDED_BYPASS_JSON: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/bypass_domains_embedded.json"));
+
+fn load_embedded_presets() -> Option<(Vec<BypassPresetInfo>, u64)> {
+    match parse_api_payload(EMBEDDED_BYPASS_JSON) {
+        Ok((presets, ttl)) if !presets.is_empty() => Some((presets, ttl)),
+        _ => None,
+    }
+}
+
+/// True when a URL is configured and/or a non-empty list was embedded at build time.
+pub fn bypass_source_configured() -> bool {
+    if bypass_domains_url().is_some() {
+        return true;
+    }
+    option_env!("BIBA_BYPASS_DOMAINS_EMBEDDED").is_some() || load_embedded_presets().is_some()
 }
 
 fn cache_file_path() -> Option<PathBuf> {
@@ -395,10 +416,33 @@ pub fn background_refresh_full() {
     }
 }
 
-/// Load presets from memory, disk, or network (in that order when stale).
+fn apply_embedded_into_cache() -> Result<Vec<BypassPresetInfo>, String> {
+    let Some((presets, ttl)) = load_embedded_presets() else {
+        return Ok(Vec::new());
+    };
+    let url = bypass_domains_url().unwrap_or_else(|| "embedded://bypass_domains".to_string());
+    let mut state = cache_lock().lock().map_err(|e| e.to_string())?;
+    apply_presets(&mut state, presets.clone(), ttl, &url);
+    info!(
+        target: "bibavpn_desktop",
+        count = presets.len(),
+        "bypass-domains: using compile-time embedded list"
+    );
+    Ok(presets)
+}
+
+/// Load presets from memory, disk, network, or compile-time embed (in that order when stale).
 pub fn ensure_loaded(force_refresh: bool) -> Result<Vec<BypassPresetInfo>, String> {
-    let url = bypass_domains_url()
-        .ok_or_else(|| "BIBA_BYPASS_DOMAINS_URL не задан (CI secret или local .env)".to_string())?;
+    let url_opt = bypass_domains_url();
+    if url_opt.is_none() && load_embedded_presets().is_none() {
+        return Err(
+            "BIBA_BYPASS_DOMAINS_URL не задан и embedded-список пуст (CI secret / local .env)"
+                .to_string(),
+        );
+    }
+    let url = url_opt
+        .clone()
+        .unwrap_or_else(|| "embedded://bypass_domains".to_string());
 
     {
         let state = cache_lock().lock().map_err(|e| e.to_string())?;
@@ -414,17 +458,27 @@ pub fn ensure_loaded(force_refresh: bool) -> Result<Vec<BypassPresetInfo>, Strin
             info!(target: "bibavpn_desktop", count = state.presets.len(), "bypass-domains: disk cache");
             return Ok(state.presets.clone());
         }
+        // Prefer baked-in list over a cold network hop on first launch.
+        if let Ok(presets) = apply_embedded_into_cache() {
+            if !presets.is_empty() {
+                return Ok(presets);
+            }
+        }
     }
 
-    match fetch_remote(&url) {
+    let Some(remote_url) = url_opt else {
+        return apply_embedded_into_cache();
+    };
+
+    match fetch_remote(&remote_url) {
         Ok((presets, ttl)) => {
-            save_disk_cache(&url, ttl, &presets);
+            save_disk_cache(&remote_url, ttl, &presets);
             let mut state = cache_lock().lock().map_err(|e| e.to_string())?;
-            apply_presets(&mut state, presets.clone(), ttl, &url);
+            apply_presets(&mut state, presets.clone(), ttl, &remote_url);
             info!(
                 target: "bibavpn_desktop",
                 count = presets.len(),
-                url = %url,
+                url = %remote_url,
                 "bypass-domains: fetched from API"
             );
             Ok(presets)
@@ -435,13 +489,14 @@ pub fn ensure_loaded(force_refresh: bool) -> Result<Vec<BypassPresetInfo>, Strin
             if state.loaded && !state.presets.is_empty() {
                 return Ok(state.presets.clone());
             }
-            if let Some(file) = load_disk_cache(&url) {
+            if let Some(file) = load_disk_cache(&remote_url) {
                 drop(state);
                 let mut state = cache_lock().lock().map_err(|e2| e2.to_string())?;
-                apply_presets(&mut state, file.presets.clone(), file.ttl_sec, &url);
+                apply_presets(&mut state, file.presets.clone(), file.ttl_sec, &remote_url);
                 return Ok(state.presets.clone());
             }
-            Ok(Vec::new())
+            drop(state);
+            apply_embedded_into_cache()
         }
     }
 }

--- a/apps/bibavpn-desktop/src-tauri/src/lib.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/lib.rs
@@ -10,18 +10,28 @@ mod split_tunnel;
 
 #[cfg(target_os = "android")]
 mod proxy_android;
+#[cfg(target_os = "linux")]
+mod proxy_linux;
 #[cfg(target_os = "macos")]
 mod proxy_mac;
-#[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "android", target_os = "macos", target_os = "linux"))
+))]
 mod proxy_stub;
 #[cfg(windows)]
 mod proxy_win;
 
 #[cfg(target_os = "android")]
 use proxy_android::{apply_proxy, read_backup, restore, ProxyBackup};
+#[cfg(target_os = "linux")]
+use proxy_linux::{apply_proxy, read_backup, restore, ProxyBackup};
 #[cfg(target_os = "macos")]
 use proxy_mac::{apply_proxy, read_backup, restore, ProxyBackup};
-#[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "android", target_os = "macos", target_os = "linux"))
+))]
 use proxy_stub::{apply_proxy, read_backup, restore, ProxyBackup};
 #[cfg(windows)]
 use proxy_win::{apply_proxy, read_backup, restore, ProxyBackup};
@@ -616,6 +626,13 @@ fn restore_proxy_blocking(backup: Option<ProxyBackup>) -> Option<String> {
                         "прокси: запасное отключение на macOS после ошибки restore: {e2}"
                     );
                 }
+                #[cfg(target_os = "linux")]
+                if let Err(e2) = crate::proxy_linux::disable_if_residual_biba_proxy() {
+                    warn!(
+                        target: "bibavpn_desktop",
+                        "прокси: запасное отключение loopback на Linux после ошибки restore: {e2}"
+                    );
+                }
                 return Some(format!("Прокси: восстановление: {e}"));
             }
             None
@@ -634,6 +651,14 @@ fn restore_proxy_blocking(backup: Option<ProxyBackup>) -> Option<String> {
                 warn!(
                     target: "bibavpn_desktop",
                     "прокси: нет снимка настроек — запасное отключение macOS: {e}"
+                );
+                return Some(format!("Прокси: {e}"));
+            }
+            #[cfg(target_os = "linux")]
+            if let Err(e) = crate::proxy_linux::disable_if_residual_biba_proxy() {
+                warn!(
+                    target: "bibavpn_desktop",
+                    "прокси: нет снимка настроек — запасная очистка loopback Linux: {e}"
                 );
                 return Some(format!("Прокси: {e}"));
             }
@@ -1479,7 +1504,7 @@ async fn get_bypass_presets_cmd(refresh: bool) -> BypassPresetsResponse {
         Duration::from_secs(bypass_domains::HTTP_TIMEOUT_SECS + 1);
 
     let task = tauri::async_runtime::spawn_blocking(move || {
-        let configured = bypass_domains::bypass_domains_url().is_some();
+        let configured = bypass_domains::bypass_source_configured();
         match bypass_domains::ensure_loaded(refresh) {
             Ok(presets) => {
                 let error = if configured && presets.is_empty() {
@@ -1507,12 +1532,12 @@ async fn get_bypass_presets_cmd(refresh: bool) -> BypassPresetsResponse {
         Ok(Ok(response)) => response,
         Ok(Err(e)) => BypassPresetsResponse {
             presets: bypass_domains::cached_presets_or_empty(),
-            configured: bypass_domains::bypass_domains_url().is_some(),
+            configured: bypass_domains::bypass_source_configured(),
             error: Some(format!("bypass presets task: {e}")),
         },
         Err(_) => BypassPresetsResponse {
             presets: bypass_domains::cached_presets_or_empty(),
-            configured: bypass_domains::bypass_domains_url().is_some(),
+            configured: bypass_domains::bypass_source_configured(),
             error: Some("Таймаут загрузки списков обхода (2 с)".into()),
         },
     }
@@ -1520,7 +1545,7 @@ async fn get_bypass_presets_cmd(refresh: bool) -> BypassPresetsResponse {
 
 fn prefetch_bypass_domains() {
     std::thread::spawn(|| {
-        if bypass_domains::bypass_domains_url().is_none() {
+        if !bypass_domains::bypass_source_configured() {
             return;
         }
         let _ = bypass_domains::ensure_loaded(false);

--- a/apps/bibavpn-desktop/src-tauri/src/proxy_linux.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/proxy_linux.rs
@@ -1,11 +1,17 @@
-//! Системный прокси Linux через GNOME GSettings (`org.gnome.system.proxy`).
-//! Работает на GNOME / Pop!_OS / COSMIC и приложениях, читающих libproxy/GProxyResolver.
-//! Split-tunnel: домены в `ignore-hosts` (прямой выход, как WinInet ProxyOverride / macOS bypass).
+//! Системный прокси Linux:
+//! 1) GNOME GSettings (`org.gnome.system.proxy`) — браузеры / часть GNOME-стека
+//! 2) Session env (`ALL_PROXY` / `http_proxy` …) через systemd --user + dbus —
+//!    для приложений, читающих env (на COSMIC libproxy+gsettings часто даёт `direct://`)
+//! 3) Telegram Desktop (официальный бинарник): «Use system proxy» на Linux не работает
+//!    (force-disabled upstream) — открываем `tg://socks?server=…&port=…` (явный SOCKS5)
 //!
-//! Schema notes: only `org.gnome.system.proxy.http` has an `enabled` key (unused by GNOME —
-//! a protocol is active when its `host` is non-empty). https/ftp/socks expose only host+port.
+//! Split-tunnel: домены в `ignore-hosts` (+ `NO_PROXY`).
 
+use std::collections::HashMap;
+use std::env;
+use std::fs;
 use std::io;
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 const SCHEMA: &str = "org.gnome.system.proxy";
@@ -13,6 +19,17 @@ const SCHEMA_HTTP: &str = "org.gnome.system.proxy.http";
 const SCHEMA_HTTPS: &str = "org.gnome.system.proxy.https";
 const SCHEMA_SOCKS: &str = "org.gnome.system.proxy.socks";
 const SCHEMA_FTP: &str = "org.gnome.system.proxy.ftp";
+
+const PROXY_ENV_KEYS: &[&str] = &[
+    "ALL_PROXY",
+    "all_proxy",
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "NO_PROXY",
+    "no_proxy",
+];
 
 #[derive(Debug, Clone)]
 struct HttpSlotBackup {
@@ -27,6 +44,12 @@ struct HostPortBackup {
     port: i32,
 }
 
+#[derive(Debug, Clone, Default)]
+struct EnvBackup {
+    /// Previous systemd --user environment values (None = key was unset).
+    values: HashMap<String, Option<String>>,
+}
+
 #[derive(Debug, Clone)]
 pub struct ProxyBackup {
     mode: String,
@@ -36,6 +59,7 @@ pub struct ProxyBackup {
     https: HostPortBackup,
     socks: HostPortBackup,
     ftp: HostPortBackup,
+    env: EnvBackup,
 }
 
 fn gsettings_available() -> bool {
@@ -142,7 +166,6 @@ fn write_host_port(schema: &str, slot: &HostPortBackup) -> Result<(), String> {
     Ok(())
 }
 
-/// Convert Win-style `*.example.com` to GNOME ignore-hosts `.example.com`.
 fn normalize_ignore_host(host: &str) -> String {
     let t = host.trim();
     if let Some(rest) = t.strip_prefix("*.") {
@@ -210,6 +233,311 @@ fn schema_exists() -> bool {
     gsettings_get(SCHEMA, "mode").is_ok()
 }
 
+fn read_systemd_user_environment() -> HashMap<String, String> {
+    let out = Command::new("systemctl")
+        .args(["--user", "show-environment"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output();
+    let Ok(out) = out else {
+        return HashMap::new();
+    };
+    if !out.status.success() {
+        return HashMap::new();
+    }
+    let mut map = HashMap::new();
+    for line in String::from_utf8_lossy(&out.stdout).lines() {
+        let Some((k, v)) = line.split_once('=') else {
+            continue;
+        };
+        map.insert(k.to_string(), v.to_string());
+    }
+    map
+}
+
+fn snapshot_proxy_env() -> EnvBackup {
+    let current = read_systemd_user_environment();
+    let mut values = HashMap::new();
+    for key in PROXY_ENV_KEYS {
+        values.insert((*key).to_string(), current.get(*key).cloned());
+    }
+    EnvBackup { values }
+}
+
+fn no_proxy_list(split_tunnel_hosts: &[String]) -> String {
+    let mut hosts = vec![
+        "localhost".into(),
+        "127.0.0.1".into(),
+        "::1".into(),
+        "tauri.localhost".into(),
+    ];
+    for h in split_tunnel_hosts {
+        let n = normalize_ignore_host(h);
+        // NO_PROXY uses host/domain forms; strip leading dot for broader match.
+        let n = n.trim_start_matches('.').to_string();
+        if !n.is_empty() && !hosts.iter().any(|x: &String| x.eq_ignore_ascii_case(&n)) {
+            hosts.push(n);
+        }
+    }
+    hosts.join(",")
+}
+
+fn proxy_env_assignments(
+    http_host: &str,
+    http_port: i32,
+    socks_host: &str,
+    socks_port: i32,
+    split_tunnel_hosts: &[String],
+) -> Vec<(String, String)> {
+    let http = format!("http://{http_host}:{http_port}");
+    // Qt / Telegram read all_proxy; socks5h = DNS via proxy.
+    let socks = format!("socks5h://{socks_host}:{socks_port}");
+    let no_proxy = no_proxy_list(split_tunnel_hosts);
+    vec![
+        ("ALL_PROXY".into(), socks.clone()),
+        ("all_proxy".into(), socks),
+        ("HTTP_PROXY".into(), http.clone()),
+        ("http_proxy".into(), http.clone()),
+        ("HTTPS_PROXY".into(), http.clone()),
+        ("https_proxy".into(), http),
+        ("NO_PROXY".into(), no_proxy.clone()),
+        ("no_proxy".into(), no_proxy),
+    ]
+}
+
+fn set_systemd_user_environment(vars: &[(String, String)]) -> Result<(), String> {
+    if vars.is_empty() {
+        return Ok(());
+    }
+    let mut cmd = Command::new("systemctl");
+    cmd.args(["--user", "set-environment"]);
+    for (k, v) in vars {
+        cmd.arg(format!("{k}={v}"));
+    }
+    let out = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("systemctl --user set-environment: {e}"))?;
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr);
+        return Err(format!(
+            "systemctl --user set-environment: {}",
+            err.trim()
+        ));
+    }
+    Ok(())
+}
+
+fn unset_systemd_user_environment(keys: &[&str]) -> Result<(), String> {
+    if keys.is_empty() {
+        return Ok(());
+    }
+    let mut cmd = Command::new("systemctl");
+    cmd.args(["--user", "unset-environment"]);
+    cmd.args(keys);
+    let out = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("systemctl --user unset-environment: {e}"))?;
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr);
+        return Err(format!(
+            "systemctl --user unset-environment: {}",
+            err.trim()
+        ));
+    }
+    Ok(())
+}
+
+fn dbus_update_activation_environment(vars: &[(String, String)]) -> Result<(), String> {
+    if vars.is_empty() {
+        return Ok(());
+    }
+    let mut cmd = Command::new("dbus-update-activation-environment");
+    cmd.arg("--systemd");
+    for (k, v) in vars {
+        cmd.env(k, v);
+        cmd.arg(k);
+    }
+    let out = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("dbus-update-activation-environment: {e}"))?;
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr);
+        // Non-fatal on minimal sessions — systemd env still helps some launchers.
+        return Err(format!(
+            "dbus-update-activation-environment: {}",
+            err.trim()
+        ));
+    }
+    Ok(())
+}
+
+fn apply_session_env(
+    http_host: &str,
+    http_port: i32,
+    socks_host: &str,
+    socks_port: i32,
+    split_tunnel_hosts: &[String],
+) {
+    let vars =
+        proxy_env_assignments(http_host, http_port, socks_host, socks_port, split_tunnel_hosts);
+    let _ = set_systemd_user_environment(&vars);
+    let _ = dbus_update_activation_environment(&vars);
+}
+
+fn restore_session_env(backup: &EnvBackup) {
+    let mut to_set = Vec::new();
+    let mut to_unset = Vec::new();
+    for key in PROXY_ENV_KEYS {
+        match backup.values.get(*key) {
+            Some(Some(v)) => to_set.push(((*key).to_string(), v.clone())),
+            _ => to_unset.push(*key),
+        }
+    }
+    if !to_unset.is_empty() {
+        let _ = unset_systemd_user_environment(&to_unset);
+    }
+    if !to_set.is_empty() {
+        let _ = set_systemd_user_environment(&to_set);
+        let _ = dbus_update_activation_environment(&to_set);
+    } else {
+        // Clear activation env keys we unset (best-effort: set empty).
+        let cleared: Vec<(String, String)> = to_unset
+            .iter()
+            .map(|k| ((*k).to_string(), String::new()))
+            .collect();
+        let _ = dbus_update_activation_environment(&cleared);
+    }
+}
+
+/// Official Telegram Desktop ignores «Use system proxy» on non-sandboxed Linux.
+/// Explicit SOCKS5 via deep link is the supported path (user confirms in Telegram UI).
+fn open_telegram_socks(host: &str, port: i32) {
+    let url = format!("tg://socks?server={host}&port={port}");
+    // Prefer xdg-open / gio so the desktop MimeType handler forwards %U to the running instance.
+    for (bin, args) in [
+        ("xdg-open", vec![url.as_str()]),
+        ("gio", vec!["open", url.as_str()]),
+    ] {
+        let ok = Command::new(bin)
+            .args(&args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if ok {
+            notify_telegram_socks(host, port);
+            return;
+        }
+    }
+    // Fallback: launch binary with URL (may start a second process that hands off via local socket).
+    if let Some(exe) = find_telegram_exe() {
+        let mut cmd = Command::new(exe);
+        cmd.arg(&url)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            unsafe {
+                cmd.pre_exec(|| {
+                    libc::setsid();
+                    Ok(())
+                });
+            }
+        }
+        let _ = cmd.spawn();
+    }
+    notify_telegram_socks(host, port);
+}
+
+fn find_telegram_exe() -> Option<PathBuf> {
+    let Ok(entries) = fs::read_dir("/proc") else {
+        return None;
+    };
+    for ent in entries.flatten() {
+        let name = ent.file_name();
+        if name.to_str().and_then(|s| s.parse::<i32>().ok()).is_none() {
+            continue;
+        }
+        let Ok(comm) = fs::read_to_string(ent.path().join("comm")) else {
+            continue;
+        };
+        let comm = comm.trim();
+        if comm != "Telegram" && comm != "telegram-desktop" {
+            continue;
+        }
+        if let Ok(exe) = fs::read_link(ent.path().join("exe")) {
+            if exe.exists() {
+                return Some(exe);
+            }
+        }
+    }
+    if let Ok(home) = env::var("HOME") {
+        let p = PathBuf::from(home).join("opt/Telegram/Telegram");
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    for candidate in ["/usr/bin/telegram-desktop", "/usr/bin/Telegram"] {
+        let p = PathBuf::from(candidate);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    which_bin("telegram-desktop").or_else(|| which_bin("Telegram"))
+}
+
+fn which_bin(name: &str) -> Option<PathBuf> {
+    let out = Command::new("which")
+        .arg(name)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(s))
+    }
+}
+
+fn notify_telegram_socks(host: &str, port: i32) {
+    let body = format!(
+        "В Telegram подтвердите SOCKS5 {host}:{port}\n\
+         (или Settings → Advanced → Connection type → SOCKS5).\n\
+         «Use system proxy» на Linux в официальном Telegram не работает."
+    );
+    let _ = Command::new("notify-send")
+        .args([
+            "--app-name=BibaVPN",
+            "--urgency=normal",
+            "Telegram: нужен явный SOCKS5",
+            &body,
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
 pub fn read_backup() -> io::Result<ProxyBackup> {
     if !gsettings_available() {
         return Err(io::Error::new(
@@ -244,6 +572,7 @@ pub fn read_backup() -> io::Result<ProxyBackup> {
         https,
         socks,
         ftp,
+        env: snapshot_proxy_env(),
     })
 }
 
@@ -257,7 +586,7 @@ fn split_host_port(hp: &str) -> Result<(String, i32), String> {
 
 pub fn apply_proxy(
     http_host_port: &str,
-    _socks_host_port: &str,
+    socks_host_port: &str,
     _prior_proxy_override: Option<&str>,
     split_tunnel_hosts: &[String],
 ) -> Result<(), String> {
@@ -273,27 +602,40 @@ pub fn apply_proxy(
         );
     }
 
-    let (host, port) = split_host_port(http_host_port)?;
+    let (http_host, http_port) = split_host_port(http_host_port)?;
+    let (socks_host, socks_port) = split_host_port(socks_host_port)?;
     let existing_ignore = gsettings_get(SCHEMA, "ignore-hosts")
         .unwrap_or_else(|_| "['localhost', '127.0.0.0/8', '::1']".to_string());
     let merged_ignore = merge_ignore_hosts(&existing_ignore, split_tunnel_hosts);
 
-    // Manual HTTP/HTTPS only — clear SOCKS host so it is not advertised (same as Win/macOS).
     gsettings_set(SCHEMA, "mode", "'manual'")?;
-    gsettings_set(SCHEMA, "use-same-proxy", "true")?;
+    gsettings_set(SCHEMA, "use-same-proxy", "false")?;
     gsettings_set(SCHEMA, "ignore-hosts", &merged_ignore)?;
 
-    gsettings_set(SCHEMA_HTTP, "host", &format_gvariant_string(&host))?;
-    gsettings_set(SCHEMA_HTTP, "port", &port.to_string())?;
+    gsettings_set(SCHEMA_HTTP, "host", &format_gvariant_string(&http_host))?;
+    gsettings_set(SCHEMA_HTTP, "port", &http_port.to_string())?;
     gsettings_set(SCHEMA_HTTP, "enabled", "true")?;
 
-    gsettings_set(SCHEMA_HTTPS, "host", &format_gvariant_string(&host))?;
-    gsettings_set(SCHEMA_HTTPS, "port", &port.to_string())?;
+    gsettings_set(SCHEMA_HTTPS, "host", &format_gvariant_string(&http_host))?;
+    gsettings_set(SCHEMA_HTTPS, "port", &http_port.to_string())?;
 
-    gsettings_set(SCHEMA_SOCKS, "host", "''")?;
-    gsettings_set(SCHEMA_SOCKS, "port", "0")?;
+    gsettings_set(SCHEMA_SOCKS, "host", &format_gvariant_string(&socks_host))?;
+    gsettings_set(SCHEMA_SOCKS, "port", &socks_port.to_string())?;
+
     gsettings_set(SCHEMA_FTP, "host", "''")?;
     gsettings_set(SCHEMA_FTP, "port", "0")?;
+
+    // COSMIC: gsettings alone is often not enough (libproxy returns direct://).
+    // Env snapshot for restore is taken in read_backup() before apply.
+    apply_session_env(
+        &http_host,
+        http_port,
+        &socks_host,
+        socks_port,
+        split_tunnel_hosts,
+    );
+    // Telegram: do not rely on system proxy / env — open explicit SOCKS5 deep link.
+    open_telegram_socks(&socks_host, socks_port);
 
     Ok(())
 }
@@ -314,6 +656,7 @@ pub fn restore(backup: &ProxyBackup) -> Result<(), String> {
     )?;
     gsettings_set(SCHEMA, "ignore-hosts", &backup.ignore_hosts)?;
     gsettings_set(SCHEMA, "mode", &format_gvariant_string(&backup.mode))?;
+    restore_session_env(&backup.env);
     Ok(())
 }
 
@@ -334,7 +677,8 @@ pub fn disable_if_residual_biba_proxy() -> Result<(), String> {
             "127.0.0.1" | "localhost"
         )
     };
-    if is_loopback(&http.host) || is_loopback(&https.host) {
+    let socks = read_host_port(SCHEMA_SOCKS)?;
+    if is_loopback(&http.host) || is_loopback(&https.host) || is_loopback(&socks.host) {
         gsettings_set(SCHEMA, "mode", "'none'")?;
         gsettings_set(SCHEMA_HTTP, "host", "''")?;
         gsettings_set(SCHEMA_HTTP, "port", "0")?;
@@ -343,6 +687,7 @@ pub fn disable_if_residual_biba_proxy() -> Result<(), String> {
         gsettings_set(SCHEMA_HTTPS, "port", "0")?;
         gsettings_set(SCHEMA_SOCKS, "host", "''")?;
         gsettings_set(SCHEMA_SOCKS, "port", "0")?;
+        let _ = unset_systemd_user_environment(PROXY_ENV_KEYS);
     }
     Ok(())
 }
@@ -363,5 +708,14 @@ mod tests {
         assert!(merged.contains("localhost"));
         assert!(merged.contains(".bank.ru"));
         assert!(merged.contains("127.0.0.0/8"));
+    }
+
+    #[test]
+    fn proxy_env_contains_socks_and_http() {
+        let v = proxy_env_assignments("127.0.0.1", 8080, "127.0.0.1", 1080, &[]);
+        let map: HashMap<_, _> = v.into_iter().collect();
+        assert_eq!(map.get("all_proxy").unwrap(), "socks5h://127.0.0.1:1080");
+        assert_eq!(map.get("https_proxy").unwrap(), "http://127.0.0.1:8080");
+        assert!(map.get("no_proxy").unwrap().contains("localhost"));
     }
 }

--- a/apps/bibavpn-desktop/src-tauri/src/proxy_linux.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/proxy_linux.rs
@@ -1,0 +1,367 @@
+//! Системный прокси Linux через GNOME GSettings (`org.gnome.system.proxy`).
+//! Работает на GNOME / Pop!_OS / COSMIC и приложениях, читающих libproxy/GProxyResolver.
+//! Split-tunnel: домены в `ignore-hosts` (прямой выход, как WinInet ProxyOverride / macOS bypass).
+//!
+//! Schema notes: only `org.gnome.system.proxy.http` has an `enabled` key (unused by GNOME —
+//! a protocol is active when its `host` is non-empty). https/ftp/socks expose only host+port.
+
+use std::io;
+use std::process::{Command, Stdio};
+
+const SCHEMA: &str = "org.gnome.system.proxy";
+const SCHEMA_HTTP: &str = "org.gnome.system.proxy.http";
+const SCHEMA_HTTPS: &str = "org.gnome.system.proxy.https";
+const SCHEMA_SOCKS: &str = "org.gnome.system.proxy.socks";
+const SCHEMA_FTP: &str = "org.gnome.system.proxy.ftp";
+
+#[derive(Debug, Clone)]
+struct HttpSlotBackup {
+    enabled: bool,
+    host: String,
+    port: i32,
+}
+
+#[derive(Debug, Clone)]
+struct HostPortBackup {
+    host: String,
+    port: i32,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProxyBackup {
+    mode: String,
+    use_same_proxy: bool,
+    ignore_hosts: String,
+    http: HttpSlotBackup,
+    https: HostPortBackup,
+    socks: HostPortBackup,
+    ftp: HostPortBackup,
+}
+
+fn gsettings_available() -> bool {
+    Command::new("gsettings")
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn gsettings_get(schema: &str, key: &str) -> Result<String, String> {
+    let out = Command::new("gsettings")
+        .args(["get", schema, key])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("gsettings get {schema} {key}: {e}"))?;
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr);
+        let msg = err.trim();
+        return Err(format!(
+            "gsettings get {schema} {key}: {}",
+            if msg.is_empty() { "failed" } else { msg }
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn gsettings_set(schema: &str, key: &str, value: &str) -> Result<(), String> {
+    let out = Command::new("gsettings")
+        .args(["set", schema, key, value])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("gsettings set {schema} {key}: {e}"))?;
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr);
+        let msg = err.trim();
+        return Err(format!(
+            "gsettings set {schema} {key}: {}",
+            if msg.is_empty() { "failed" } else { msg }
+        ));
+    }
+    Ok(())
+}
+
+fn parse_gvariant_string(raw: &str) -> String {
+    let t = raw.trim();
+    if t == "''" || t == "\"\"" {
+        return String::new();
+    }
+    if (t.starts_with('\'') && t.ends_with('\'')) || (t.starts_with('"') && t.ends_with('"')) {
+        return t[1..t.len() - 1].replace("\\'", "'").replace("\\\"", "\"");
+    }
+    t.to_string()
+}
+
+fn parse_gvariant_bool(raw: &str) -> bool {
+    matches!(raw.trim(), "true" | "True" | "1")
+}
+
+fn parse_gvariant_i32(raw: &str) -> i32 {
+    raw.trim().parse().unwrap_or(0)
+}
+
+fn format_gvariant_string(s: &str) -> String {
+    format!("'{}'", s.replace('\\', "\\\\").replace('\'', "\\'"))
+}
+
+fn read_http_slot() -> Result<HttpSlotBackup, String> {
+    Ok(HttpSlotBackup {
+        enabled: parse_gvariant_bool(&gsettings_get(SCHEMA_HTTP, "enabled")?),
+        host: parse_gvariant_string(&gsettings_get(SCHEMA_HTTP, "host")?),
+        port: parse_gvariant_i32(&gsettings_get(SCHEMA_HTTP, "port")?),
+    })
+}
+
+fn read_host_port(schema: &str) -> Result<HostPortBackup, String> {
+    Ok(HostPortBackup {
+        host: parse_gvariant_string(&gsettings_get(schema, "host")?),
+        port: parse_gvariant_i32(&gsettings_get(schema, "port")?),
+    })
+}
+
+fn write_http_slot(slot: &HttpSlotBackup) -> Result<(), String> {
+    gsettings_set(SCHEMA_HTTP, "host", &format_gvariant_string(&slot.host))?;
+    gsettings_set(SCHEMA_HTTP, "port", &slot.port.to_string())?;
+    gsettings_set(
+        SCHEMA_HTTP,
+        "enabled",
+        if slot.enabled { "true" } else { "false" },
+    )?;
+    Ok(())
+}
+
+fn write_host_port(schema: &str, slot: &HostPortBackup) -> Result<(), String> {
+    gsettings_set(schema, "host", &format_gvariant_string(&slot.host))?;
+    gsettings_set(schema, "port", &slot.port.to_string())?;
+    Ok(())
+}
+
+/// Convert Win-style `*.example.com` to GNOME ignore-hosts `.example.com`.
+fn normalize_ignore_host(host: &str) -> String {
+    let t = host.trim();
+    if let Some(rest) = t.strip_prefix("*.") {
+        format!(".{rest}")
+    } else {
+        t.to_string()
+    }
+}
+
+fn parse_ignore_hosts_list(raw: &str) -> Vec<String> {
+    let t = raw.trim();
+    let inner = t
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(t);
+    let mut out = Vec::new();
+    for part in inner.split(',') {
+        let p = part.trim();
+        if p.is_empty() {
+            continue;
+        }
+        let s = parse_gvariant_string(p);
+        if !s.is_empty() {
+            out.push(s);
+        }
+    }
+    out
+}
+
+fn format_ignore_hosts_list(hosts: &[String]) -> String {
+    let mut parts = Vec::with_capacity(hosts.len());
+    for h in hosts {
+        parts.push(format_gvariant_string(h));
+    }
+    format!("[{}]", parts.join(", "))
+}
+
+fn merge_ignore_hosts(existing_raw: &str, split_tunnel_hosts: &[String]) -> String {
+    let mut hosts = parse_ignore_hosts_list(existing_raw);
+    for h in split_tunnel_hosts {
+        let n = normalize_ignore_host(h);
+        if !n.is_empty() && !hosts.iter().any(|x| x.eq_ignore_ascii_case(&n)) {
+            hosts.push(n);
+        }
+    }
+    for req in [
+        "localhost",
+        "127.0.0.0/8",
+        "::1",
+        "tauri.localhost",
+        "steamloopback.host",
+        ".steamloopback.host",
+        "client-update.steamstatic.com",
+        "client-update.akamai.steamstatic.com",
+        "client-update.fastly.steamstatic.com",
+    ] {
+        if !hosts.iter().any(|x| x.eq_ignore_ascii_case(req)) {
+            hosts.push(req.to_string());
+        }
+    }
+    format_ignore_hosts_list(&hosts)
+}
+
+fn schema_exists() -> bool {
+    gsettings_get(SCHEMA, "mode").is_ok()
+}
+
+pub fn read_backup() -> io::Result<ProxyBackup> {
+    if !gsettings_available() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "gsettings не найден (нужен GLib/GNOME proxy stack)",
+        ));
+    }
+    if !schema_exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "схема org.gnome.system.proxy недоступна",
+        ));
+    }
+    let mode = parse_gvariant_string(
+        &gsettings_get(SCHEMA, "mode").map_err(|e| io::Error::new(io::ErrorKind::Other, e))?,
+    );
+    let use_same_proxy = parse_gvariant_bool(
+        &gsettings_get(SCHEMA, "use-same-proxy")
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?,
+    );
+    let ignore_hosts = gsettings_get(SCHEMA, "ignore-hosts")
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let http = read_http_slot().map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let https = read_host_port(SCHEMA_HTTPS).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let socks = read_host_port(SCHEMA_SOCKS).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let ftp = read_host_port(SCHEMA_FTP).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    Ok(ProxyBackup {
+        mode,
+        use_same_proxy,
+        ignore_hosts,
+        http,
+        https,
+        socks,
+        ftp,
+    })
+}
+
+fn split_host_port(hp: &str) -> Result<(String, i32), String> {
+    let (h, p) = hp
+        .rsplit_once(':')
+        .ok_or_else(|| format!("неверный host:port: {hp}"))?;
+    let port: u16 = p.parse().map_err(|_| format!("неверный порт: {p}"))?;
+    Ok((h.to_string(), i32::from(port)))
+}
+
+pub fn apply_proxy(
+    http_host_port: &str,
+    _socks_host_port: &str,
+    _prior_proxy_override: Option<&str>,
+    split_tunnel_hosts: &[String],
+) -> Result<(), String> {
+    if !gsettings_available() {
+        return Err(
+            "Системный прокси: не найден gsettings. Нужен GNOME/Pop/COSMIC (org.gnome.system.proxy)."
+                .into(),
+        );
+    }
+    if !schema_exists() {
+        return Err(
+            "Системный прокси: схема org.gnome.system.proxy недоступна на этой системе.".into(),
+        );
+    }
+
+    let (host, port) = split_host_port(http_host_port)?;
+    let existing_ignore = gsettings_get(SCHEMA, "ignore-hosts")
+        .unwrap_or_else(|_| "['localhost', '127.0.0.0/8', '::1']".to_string());
+    let merged_ignore = merge_ignore_hosts(&existing_ignore, split_tunnel_hosts);
+
+    // Manual HTTP/HTTPS only — clear SOCKS host so it is not advertised (same as Win/macOS).
+    gsettings_set(SCHEMA, "mode", "'manual'")?;
+    gsettings_set(SCHEMA, "use-same-proxy", "true")?;
+    gsettings_set(SCHEMA, "ignore-hosts", &merged_ignore)?;
+
+    gsettings_set(SCHEMA_HTTP, "host", &format_gvariant_string(&host))?;
+    gsettings_set(SCHEMA_HTTP, "port", &port.to_string())?;
+    gsettings_set(SCHEMA_HTTP, "enabled", "true")?;
+
+    gsettings_set(SCHEMA_HTTPS, "host", &format_gvariant_string(&host))?;
+    gsettings_set(SCHEMA_HTTPS, "port", &port.to_string())?;
+
+    gsettings_set(SCHEMA_SOCKS, "host", "''")?;
+    gsettings_set(SCHEMA_SOCKS, "port", "0")?;
+    gsettings_set(SCHEMA_FTP, "host", "''")?;
+    gsettings_set(SCHEMA_FTP, "port", "0")?;
+
+    Ok(())
+}
+
+pub fn restore(backup: &ProxyBackup) -> Result<(), String> {
+    write_http_slot(&backup.http)?;
+    write_host_port(SCHEMA_HTTPS, &backup.https)?;
+    write_host_port(SCHEMA_SOCKS, &backup.socks)?;
+    write_host_port(SCHEMA_FTP, &backup.ftp)?;
+    gsettings_set(
+        SCHEMA,
+        "use-same-proxy",
+        if backup.use_same_proxy {
+            "true"
+        } else {
+            "false"
+        },
+    )?;
+    gsettings_set(SCHEMA, "ignore-hosts", &backup.ignore_hosts)?;
+    gsettings_set(SCHEMA, "mode", &format_gvariant_string(&backup.mode))?;
+    Ok(())
+}
+
+/// Если снимок потерян, а manual-прокси указывает на loopback Biba — выключить.
+pub fn disable_if_residual_biba_proxy() -> Result<(), String> {
+    if !gsettings_available() || !schema_exists() {
+        return Ok(());
+    }
+    let mode = parse_gvariant_string(&gsettings_get(SCHEMA, "mode")?);
+    if mode != "manual" {
+        return Ok(());
+    }
+    let http = read_http_slot()?;
+    let https = read_host_port(SCHEMA_HTTPS)?;
+    let is_loopback = |host: &str| {
+        matches!(
+            host.trim().to_ascii_lowercase().as_str(),
+            "127.0.0.1" | "localhost"
+        )
+    };
+    if is_loopback(&http.host) || is_loopback(&https.host) {
+        gsettings_set(SCHEMA, "mode", "'none'")?;
+        gsettings_set(SCHEMA_HTTP, "host", "''")?;
+        gsettings_set(SCHEMA_HTTP, "port", "0")?;
+        gsettings_set(SCHEMA_HTTP, "enabled", "false")?;
+        gsettings_set(SCHEMA_HTTPS, "host", "''")?;
+        gsettings_set(SCHEMA_HTTPS, "port", "0")?;
+        gsettings_set(SCHEMA_SOCKS, "host", "''")?;
+        gsettings_set(SCHEMA_SOCKS, "port", "0")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_star_domains() {
+        assert_eq!(normalize_ignore_host("*.example.com"), ".example.com");
+        assert_eq!(normalize_ignore_host("example.com"), "example.com");
+    }
+
+    #[test]
+    fn merge_adds_loopback_and_split() {
+        let merged = merge_ignore_hosts("['localhost']", &["*.bank.ru".into()]);
+        assert!(merged.contains("localhost"));
+        assert!(merged.contains(".bank.ru"));
+        assert!(merged.contains("127.0.0.0/8"));
+    }
+}

--- a/apps/bibavpn-desktop/src-tauri/src/split_tunnel.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/split_tunnel.rs
@@ -1,10 +1,12 @@
-//! Split-tunnel: домены в обход системного HTTP-прокси (Windows ProxyOverride / macOS bypass).
-//! Списки доменов берутся из API [`crate::bypass_domains`] (не захардкожены в репозитории).
+//! Split-tunnel: домены в обход системного HTTP-прокси
+//! (Windows ProxyOverride / macOS bypass / Linux GSettings `ignore-hosts`).
+//! Списки доменов — из API / disk cache / compile-time embed ([`crate::bypass_domains`]).
 
 use crate::bypass_domains;
 use crate::config::TunnelProfile;
 
-/// Домены для WinInet ProxyOverride / macOS bypass (без обязательных loopback — их добавляет платформа).
+/// Домены для WinInet ProxyOverride / macOS bypass / Linux ignore-hosts
+/// (без обязательных loopback — их добавляет платформа).
 pub fn bypass_domains_for_profile(profile: &TunnelProfile) -> Vec<String> {
     if !profile.split_tunnel_enabled {
         return Vec::new();


### PR DESCRIPTION
## Summary
- Add Linux desktop system proxy via GNOME gsettings + session env (`ALL_PROXY` / `HTTP(S)_PROXY` / `NO_PROXY`), with split-tunnel hosts in `ignore-hosts`.
- On connect, open Telegram `tg://socks` for explicit SOCKS5 (official Linux Telegram ignores «Use system proxy»).
- CI fetches bypass-domains JSON (`BIBA_BYPASS_DOMAINS_URL`) before desktop/android builds and bakes it into the binary; new `desktop-linux.yml` workflow and Linux artifact in releases.

## Test plan
- [ ] Confirm desktop-linux / windows / macos / android workflows run the `ci-fetch-bypass-domains.sh` step
- [ ] Set repo secret `BIBA_BYPASS_DOMAINS_URL` (required for release/`workflow_call`)
- [ ] On Linux (GNOME/Pop/COSMIC): Connect → gsettings `org.gnome.system.proxy` is manual with local HTTP+SOCKS; Disconnect restores prior mode
- [ ] Split preset domains land in `ignore-hosts` / `NO_PROXY`
- [ ] Telegram: after Connect, confirm SOCKS5 dialog / set `127.0.0.1:<socks>` and traffic works


Made with [Cursor](https://cursor.com)