### PR TITLE
feat(android): enable domain split tunnelling via the core DNS snoop

### DIFF
--- a/apps/bibavpn-desktop/src-tauri/src/config.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/config.rs
@@ -638,6 +638,19 @@ impl TunnelProfile {
             o.insert("ws_accept_language".to_string(), json!(wal));
         }
 
+        // Domain split routing handled inside the tunnel client (`bibavpn::domain_route`):
+        // the DNS snoop learns IP -> domain from answers flowing through the UDP relay, so a
+        // SOCKS CONNECT that only carries an IP (full-TUN on mobile) still matches. Unlike the
+        // Android `excludeRoute` path this works on every API level, covers IPv6, re-learns CDN
+        // addresses live, and is not capped at 128 routes. Empty when split tunnel is off.
+        //
+        // Reads the in-memory preset cache, so callers must `bypass_domains::ensure_loaded()`
+        // *before* building this JSON or the list comes back empty.
+        let split_domains = crate::split_tunnel::bypass_domains_for_profile(self);
+        if !split_domains.is_empty() {
+            o.insert("split_bypass_domains".to_string(), json!(split_domains));
+        }
+
         serde_json::to_string(&Value::Object(o)).map_err(|e| e.to_string())
     }
 }
@@ -942,5 +955,40 @@ pub fn server_card_subtitle(cfg: &SavedConfig) -> String {
         }
     } else {
         "Не задан сервер".to_string()
+    }
+}
+
+#[cfg(test)]
+mod split_bypass_json_tests {
+    use super::TunnelProfile;
+
+    fn profile() -> TunnelProfile {
+        TunnelProfile {
+            server: "vpn.example.com:8443".to_string(),
+            token: "t".to_string(),
+            ..TunnelProfile::default()
+        }
+    }
+
+    /// The tunnel client treats an absent `split_bypass_domains` as "domain split off", so the
+    /// key must never appear just because the section exists in the profile.
+    #[test]
+    fn omitted_when_split_tunnel_disabled() {
+        let mut p = profile();
+        p.split_tunnel_enabled = false;
+        p.split_tunnel_preset_ids = vec!["banks".to_string()];
+        let json = p.start_config_json().expect("build start json");
+        assert!(!json.contains("split_bypass_domains"), "got: {json}");
+    }
+
+    /// Enabled but nothing selected resolves to an empty list — emit no key rather than `[]`,
+    /// so the client takes its cheap "bypass disabled" path.
+    #[test]
+    fn omitted_when_no_presets_selected() {
+        let mut p = profile();
+        p.split_tunnel_enabled = true;
+        p.split_tunnel_preset_ids = Vec::new();
+        let json = p.start_config_json().expect("build start json");
+        assert!(!json.contains("split_bypass_domains"), "got: {json}");
     }
 }

--- a/apps/bibavpn-desktop/src-tauri/src/lib.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/lib.rs
@@ -1203,8 +1203,11 @@ fn connect_inner(state: &AppState, app: &AppHandle) -> Result<(), String> {
     }
 
     persist_cfg(app, &g.cfg)?;
-    let json = g.cfg.start_config_json()?;
+    // Must run before `start_config_json()`: that builds `split_bypass_domains` for the
+    // tunnel client's DNS-snoop split routing out of the in-memory preset cache, so a cold
+    // cache here means an empty bypass list and silently no domain split at all.
     let _ = bypass_domains::ensure_loaded(false);
+    let json = g.cfg.start_config_json()?;
     let (split_tunnel_enabled, packages, domains, battery) = match g.cfg.active_profile() {
         Some(p) => (
             p.split_tunnel_enabled,

--- a/bibavpn/tests/split_bypass_wiring.rs
+++ b/bibavpn/tests/split_bypass_wiring.rs
@@ -1,0 +1,84 @@
+//! `split_bypass_domains` in the start JSON must actually reach `domain_route`'s
+//! process-global bypass list. The field and the DNS snoop both existed for a while, but
+//! nothing ever populated the field, so domain split routing was dead code on every
+//! platform — this test pins the wiring shut.
+//!
+//! Deliberately its own integration binary: `set_bypass_domains` mutates process-global
+//! state, and any other test parsing a start JSON without the field would clear it.
+
+use bibavpn::domain_route;
+use bibavpn::start_json_config::local_client_options_from_json_str;
+
+const PSK: &str = "0123456789abcdef0123456789abcdef";
+
+/// Minimal DNS response: one question, one A answer pointing at `ip`.
+fn dns_a_response(qname: &str, ip: [u8; 4], ttl: u32) -> Vec<u8> {
+    let mut m = Vec::new();
+    m.extend_from_slice(&[0x12, 0x34]); // id
+    m.extend_from_slice(&[0x81, 0x80]); // flags: response, RD/RA
+    m.extend_from_slice(&1u16.to_be_bytes()); // qdcount
+    m.extend_from_slice(&1u16.to_be_bytes()); // ancount
+    m.extend_from_slice(&[0, 0, 0, 0]); // nscount, arcount
+    let qstart = m.len();
+    for label in qname.split('.') {
+        m.push(label.len() as u8);
+        m.extend_from_slice(label.as_bytes());
+    }
+    m.push(0);
+    m.extend_from_slice(&1u16.to_be_bytes()); // qtype A
+    m.extend_from_slice(&1u16.to_be_bytes()); // qclass IN
+    m.push(0xC0); // answer name: compression pointer back to the question
+    m.push(qstart as u8);
+    m.extend_from_slice(&1u16.to_be_bytes()); // type A
+    m.extend_from_slice(&1u16.to_be_bytes()); // class IN
+    m.extend_from_slice(&ttl.to_be_bytes());
+    m.extend_from_slice(&4u16.to_be_bytes()); // rdlength
+    m.extend_from_slice(&ip);
+    m
+}
+
+#[test]
+fn split_bypass_domains_from_start_json_reaches_domain_route() {
+    // Entries arrive from the preset API in mixed shapes: bare host, leading dot, mixed case.
+    let j = format!(
+        r#"{{"server":"127.0.0.1:8443","token":"t","psk":"{PSK}",
+             "split_bypass_domains":["example.com","  .Video.NET "]}}"#
+    );
+    local_client_options_from_json_str(&j).expect("parse start json");
+
+    // Hostname survives (desktop SOCKS / HTTP CONNECT): match directly.
+    assert!(domain_route::should_bypass("example.com"));
+    assert!(domain_route::should_bypass("a.b.example.com"));
+    assert!(domain_route::should_bypass("EXAMPLE.COM"));
+    assert!(domain_route::should_bypass("cdn.video.net"));
+
+    // Not a suffix match — must stay in the tunnel.
+    assert!(!domain_route::should_bypass("notexample.com"));
+    assert!(!domain_route::should_bypass("example.com.evil.net"));
+    assert!(!domain_route::should_bypass("other.org"));
+
+    // Full-TUN case: tun2socks hands us a bare IP. With nothing learned yet the fail-safe
+    // must keep it on the tunnel rather than leaking it direct.
+    assert!(!domain_route::should_bypass("93.184.216.34"));
+
+    // Once the UDP relay snoops a DNS answer for a bypassed domain, that IP goes direct.
+    // This is what `excludeRoute` cannot do: the association is learned live, so a CDN
+    // rotating addresses keeps working without reconnecting.
+    domain_route::record_dns(&dns_a_response("example.com", [93, 184, 216, 34], 3600));
+    assert!(domain_route::should_bypass("93.184.216.34"));
+
+    // An IP belonging to a domain that is not on the list stays tunneled.
+    domain_route::record_dns(&dns_a_response("other.org", [198, 51, 100, 7], 3600));
+    assert!(!domain_route::should_bypass("198.51.100.7"));
+}
+
+#[test]
+fn absent_split_bypass_domains_leaves_routing_untouched() {
+    // Same process as the test above would fight over the global list, so this case is
+    // asserted through the pure decision function instead of the global convenience wrapper.
+    let map = domain_route::DomainRouteMap::new();
+    assert_eq!(
+        domain_route::decide("example.com", &[], &map, 0),
+        domain_route::Route::Tunnel
+    );
+}


### PR DESCRIPTION
## Problem

Domain-based split tunnelling did not work on Android in any practical sense. The only mechanism that actually took effect was per-app `addDisallowedApplication`.

The reason was not a missing mechanism — `bibavpn::domain_route` has had the right one all along (DNS snoop building a TTL'd `IP -> domain` map, consulted on every SOCKS `CONNECT`, with `direct_bypass_relay` egressing outside the tunnel through the `VpnService.protect()` hook). It is wired into `local_client.rs` and `udp_mux.rs` and covered by unit tests.

What was missing is the single input that switches it on: **nothing ever populated `split_bypass_domains` in the start JSON.** A repo-wide grep found exactly two references, both inside `start_json_config.rs` — the field declaration and the `set_bypass_domains()` call. So `set_bypass_domains` was always handed an empty vector, `should_bypass()` always took its cheap early-return path, and the whole snoop was dead code on every platform.

That left Android relying on `applySplitTunnelDomainBypasses()`, whose limits are severe:

- `Build.VERSION_CODES.TIRAMISU` gate — Android 13+ only
- `if (addr !is Inet4Address) continue` — AAAA answers silently dropped
- `InetAddress.getAllByName(host)` at connect time — addresses frozen, so a CDN rotation breaks bypass until reconnect (the code comment says as much)
- `MAX_DOMAIN_ROUTE_EXCLUSIONS = 128` against **5617** domains in the live preset list — roughly 2% coverage

## Changes

**`config.rs`** — `start_config_json()` now emits `split_bypass_domains` from the profile's selected presets. Omitted entirely when split tunnelling is off or nothing is selected, so the client keeps its "bypass disabled" fast path rather than receiving `[]`.

**`lib.rs`** — in the Android `connect_inner`, `bypass_domains::ensure_loaded()` now runs *before* `start_config_json()`. It previously ran after, which would have handed the JSON builder a cold cache and produced an empty list — the feature would have shipped silently broken.

**`bibavpn/tests/split_bypass_wiring.rs`** — new integration test pinning the wiring end to end: start JSON → `set_bypass_domains` → `should_bypass`, including the full-TUN path where a bare IP is resolved back to its domain from a snooped DNS answer, and the fail-safe where an unknown IP stays tunnelled. It is a separate test binary on purpose: `set_bypass_domains` mutates process-global state that other tests in the same process would clear.

## Effect on Android

| | before (`excludeRoute`) | after (core DNS snoop) |
|---|---|---|
| Android versions | 13+ only | all |
| Address family | IPv4 only | IPv4 + IPv6 |
| CDN rotation | breaks until reconnect | re-learned live from DNS TTLs |
| Capacity | 128 routes | 20k IP map, suffix matching |
| Coverage of the 5617-domain list | ~2% | all of it |

Unknown domains still resolve to `Route::Tunnel`, so the fail-safe is unchanged.

## Verification

- `cargo test -p bibavpn` — **186 passed, 0 failed** (including the 2 new ones)
- `cargo test -p bibavpn-desktop --lib` — 2 new config tests pass
- `cargo check -p bibavpn-desktop` — clean

One gap worth flagging for review: the `connect_inner` change sits inside `#[cfg(target_os = "android")]`, so it is not compiled on a macOS host, and `cargo check --target aarch64-linux-android` cannot get there either (`ring`'s build script needs the NDK's clang). The edit is a reorder of two pre-existing adjacent statements — no new bindings, both uses of `g` immutable — so it cannot introduce a type error, but CI with the NDK is what actually confirms it.

## Known limitations, unchanged by this PR

- The snoop only sees DNS that flows through the tunnel's UDP relay. Android Private DNS (DoT) or an app doing its own DoH leaves the map empty: no leak, since unknown falls back to the tunnel, but no bypass either.
- `should_bypass()` is consulted only on the TCP path; `udp_mux` only calls `record_dns`. QUIC/HTTP3 to a bypassed domain still goes through the tunnel.
- `applySplitTunnelDomainBypasses` is deliberately left untouched. It is the only mechanism that removes traffic from the TUN entirely, including UDP, so trimming the list it receives would change QUIC coverage — that needs a product decision about which domains matter for HTTP/3, not a unilateral one here. Note it also costs connect latency: it resolves hosts sequentially and blocking until it hits the 128 cap.
- On desktop the field is now populated too, but `connect_inner` there never calls `ensure_loaded`, so the list only lands if the background prefetch already warmed the cache. Closing that properly needs a bounded wait on the prefetch and is left for a follow-up.

Depends on Eljaja/bibavpn-control-plane#1 — until the preset endpoint stops returning a truncated body, there is no list to hand to any of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
