### PR TITLE
fix: Android JNI stop timeout can leave a zombie client; next nativeStart double-binds SOCKS

### DIFF
--- a/.github/agent/work/IMPLEMENT.md
+++ b/.github/agent/work/IMPLEMENT.md
@@ -1,0 +1,21 @@
+# Implementation notes
+
+**Clippy:** `cargo clippy -p bibavpn-jni -- -D warnings` fails in this environment because transitive workspace crates (`biba`, `bibavpn`) emit pre-existing warnings promoted to errors under `-D warnings`. The `bibavpn-jni` crate itself is clean: `cargo clippy -p bibavpn-jni --no-deps -- -D warnings` passes.
+
+## Summary
+
+Fixed Android JNI client lifecycle so a timed-out `nativeStop` leaves a **stopping** slot (not idle), preventing a second SOCKS client from spawning. `outbound_protect::set_hook(None)` runs only after a successful thread join. `performFullStackRestart` treats JNI `"already running"` like bootstrap: log and continue to `startVpnTunnel`.
+
+## Files changed
+
+- `apps/bibavpn-jni/src/client_slot.rs` — new Idle/Live/Stopping slot manager + unit tests
+- `apps/bibavpn-jni/src/lib.rs` — wire slot manager into `nativeStart` / `nativeStop`
+- `apps/bibavpn-jni/Cargo.toml` — add `rlib` crate-type for unit tests
+- `apps/bibavpn-desktop/src-tauri/android-bibavpn-extras/java/dev/bibavpn/BibaVpnService.kt` — `ERR_ALREADY_RUNNING` handling in `performFullStackRestart`
+
+## Tests run
+
+```bash
+cargo test -p bibavpn-jni          # 8 passed
+cargo clippy -p bibavpn-jni --no-deps -- -D warnings  # passed
+```

--- a/.github/agent/work/REVIEW.md
+++ b/.github/agent/work/REVIEW.md
@@ -1,0 +1,6 @@
+VERDICT: PASS
+
+- JNI slot matches the spec machine: timed-out stop keeps `JoinHandle`/`done_rx` in Stopping (not idle), does not clear the protect-hook callback, and does not detach.
+- `nativeStart` on Stopping waits the bounded join timeout then spawns or returns `"already running"`; a live non-stopping thread still errors; SOCKS-not-ready uses the same stop helper (`abort_pending_start` → `stop`).
+- `performFullStackRestart` treats `ERR_ALREADY_RUNNING` like bootstrap (log only, no Toast, no `setTunnelActive(false)`, no early `return@Thread`) and continues to `startVpnTunnel`.
+- Named slot tests are present with a ~100ms join timeout (timeout leaves Stopping + hook uncleared; successful join clears slot/hook and start succeeds; live thread rejects start; never two live dummies). Diff stays in the allowed files; no secrets.

--- a/.github/agent/work/SPEC.md
+++ b/.github/agent/work/SPEC.md
@@ -1,0 +1,78 @@
+# Spec
+
+## Summary
+
+Android `nativeStop` currently `take()`s `STATE` to `None`, waits 5s, then **detaches** a still-running client thread and clears `outbound_protect`. A following `nativeStart` thinks the process is idle and spawns a second tokio client, which can double-bind SOCKS (`127.0.0.1:1080`) and overwrite the protect hook while the old WSS session is still alive.
+
+Fix the JNI slot so a timed-out stop stays visible as “stopping” (fail closed / wait-then-start, never two live clients). Clear the protect hook only after the old thread has actually exited. In `BibaVpnService.performFullStackRestart`, treat JNI `"already running"` the same way `enqueueBootstrapWorker` already does: log and keep the tunnel, do not Toast-fail and `setTunnelActive(false)`.
+
+Keep the 5s stop bound (ANR). Do not join forever.
+
+## In scope
+
+- **JNI client slot** in `apps/bibavpn-jni/src/lib.rs`:
+  - After `stop_client_bounded` times out, **do not** leave `STATE == None`. Keep the `JoinHandle` / `done_rx` in a stopping slot so the process is not idle.
+  - `nativeStart` must either wait (bounded by the existing 5s stop join timeout) for that stopping thread and only then spawn, or return `"already running"`. It must never start a second client while the previous thread is still alive.
+  - `nativeStop` on an already-stopping slot may wait again (same 5s bound) and then join if the thread finished; it must not spawn anything.
+  - The SOCKS-not-ready failure path in `nativeStart` (today: `guard.take()` + `stop_client_bounded` + `set_hook(None)`) must use the same stop helper so a timeout there also leaves a stopping slot and does not clear the hook early.
+- **Protect hook:** on Android, call `bibavpn::outbound_protect::set_hook(None)` only after the client thread has joined (`done_rx` disconnected / `JoinHandle::join`). On stop timeout, leave the existing hook installed.
+- **Kotlin restart:** in `performFullStackRestart`, if `nativeStart` returns a string containing `"already running"` (same `ERR_ALREADY_RUNNING` as bootstrap), log a warning and **continue to `startVpnTunnel`**. Do not Toast, do not `setTunnelActive(false)`, do not `return@Thread` before TUN/tun2socks.
+- Extract the stop/start slot logic far enough that `cargo test -p bibavpn-jni` can cover it without a device (parameterize the join timeout so tests can use tens of milliseconds, not 5s). Holding `STATE` for that bounded wait is acceptable: Java already serializes start/stop with `nativeLifecycleLock`, and `nativeStart` already runs off the main thread.
+
+Suggested slot behavior (implement this, not a larger state machine):
+
+1. **Idle** (`None`): `nativeStart` spawns; `nativeStop` is a no-op.
+2. **Live:** `nativeStart` → `"already running"` if `!thread.is_finished()`; `nativeStop` signals shutdown and waits up to 5s.
+3. **Stopping** (shutdown already sent, thread may still run): `nativeStart` waits up to 5s for `done_rx` disconnect, joins, then spawns; if still running → `"already running"`. Never bind SOCKS twice.
+
+## Out of scope
+
+- iOS `bibavpn-ffi` unbounded join (issue #73) and any FFI `STATE` changes.
+- Server target fd leak (issue #67).
+- Background reaper thread / generation counter beyond what is required to keep a stopping slot and avoid a second spawn.
+- Aborting or `std::thread::kill` of the client thread; changing `STOP_JOIN_TIMEOUT` (5s) for production.
+- Desktop `ActiveVpn::stop`, tun2socks `Engine`, TUN recreate, bootstrap worker, or `onDestroy` teardown flow (except the restart `"already running"` branch above).
+- Wire format, `bibavpn` crate, `biba` crate, `outbound_protect.rs` API shape (JNI already calls `set_hook`; only **when** JNI calls `None` changes).
+- New Android/JUnit/device harnesses.
+
+## Files to change
+
+- `apps/bibavpn-jni/src/lib.rs` — `NativeState` / `STATE`, `stop_client_bounded`, `Java_dev_bibavpn_core_BibaNative_nativeStart`, `Java_dev_bibavpn_core_BibaNative_nativeStop`; optional small private module in the same crate if that makes the slot testable without JNI.
+- `apps/bibavpn-jni/Cargo.toml` — only if needed so unit tests compile (e.g. `crate-type = ["cdylib", "rlib"]`). Prefer the smallest Cargo change that lets `cargo test -p bibavpn-jni` run.
+- `apps/bibavpn-desktop/src-tauri/android-bibavpn-extras/java/dev/bibavpn/BibaVpnService.kt` — `performFullStackRestart` error handling for `ERR_ALREADY_RUNNING` only.
+
+## Tests
+
+Run from repo root:
+
+```bash
+cargo test -p bibavpn-jni
+cargo clippy -p bibavpn-jni -- -D warnings
+```
+
+Do **not** require `cargo test -p bibavpn` / `-p biba` (those crates are untouched). Do not add Gradle/device tests.
+
+Add unit tests next to the extracted slot logic (dummy `std::thread` that ignores shutdown and sleeps, or that exits when a test `watch` fires):
+
+- Stop timeout leaves a stopping slot (`STATE` not idle); a following start either waits until the dummy thread exits then starts once, or returns `"already running"` — never two live dummy threads.
+- Stop that joins (thread exits inside the timeout) clears the slot and a following start succeeds.
+- A test double for the protect hook is **not** cleared on timeout and **is** cleared after a successful join.
+- `nativeStart`-equivalent “already running” while a live (non-stopping) thread is still running remains an error.
+
+Use a test-only join timeout (~50–200ms), not the production 5s.
+
+## Acceptance criteria
+
+- `nativeStop` followed immediately by `nativeStart` never runs two client threads against the same SOCKS bind. If the old thread is still alive after the bounded wait, start fails closed with `"already running"`.
+- A stop that hits the 5s timeout does not clear `outbound_protect` until that old thread has joined.
+- Network-change / full-stack restart (`performFullStackRestart`): `"already running"` from JNI does not Toast, does not `setTunnelActive(false)`, and does not skip `startVpnTunnel`.
+- `nativeStop` still returns within the existing 5s bound (no unbounded `join` on the teardown path).
+- `cargo test -p bibavpn-jni` and `cargo clippy -p bibavpn-jni -- -D warnings` pass.
+
+## Non-goals
+
+- Fixing every Android lifecycle race (screen-off battery saver, duplicate `onStartCommand`, tun2socks join).
+- Making stop instantaneous or aborting in-flight `getaddrinfo` / tokio runtime drop.
+- Changing the public JNI signatures of `nativeStart` / `nativeStop`.
+- Documenting or renaming the `"already running"` error string (Kotlin already matches it).
+- Camouflage, REALITY, proto-3, or any on-wire change.

--- a/apps/bibavpn-desktop/src-tauri/android-bibavpn-extras/java/dev/bibavpn/BibaVpnService.kt
+++ b/apps/bibavpn-desktop/src-tauri/android-bibavpn-extras/java/dev/bibavpn/BibaVpnService.kt
@@ -405,17 +405,24 @@ class BibaVpnService : VpnService() {
                                 e.message ?: e.javaClass.simpleName
                             }
                         if (err != null) {
-                            Log.e(TAG, "$reason: nativeStart failed: $err")
-                            allowScreenOnStackRestart = true
-                            mainHandler.post {
-                                setTunnelActive(false)
-                                android.widget.Toast.makeText(
-                                    applicationContext,
-                                    err,
-                                    android.widget.Toast.LENGTH_LONG,
-                                ).show()
+                            if (err.contains(ERR_ALREADY_RUNNING, ignoreCase = true)) {
+                                Log.w(
+                                    TAG,
+                                    "$reason: nativeStart: $err — оставляем туннель как есть",
+                                )
+                            } else {
+                                Log.e(TAG, "$reason: nativeStart failed: $err")
+                                allowScreenOnStackRestart = true
+                                mainHandler.post {
+                                    setTunnelActive(false)
+                                    android.widget.Toast.makeText(
+                                        applicationContext,
+                                        err,
+                                        android.widget.Toast.LENGTH_LONG,
+                                    ).show()
+                                }
+                                return@Thread
                             }
-                            return@Thread
                         }
                     }
                     if (!startVpnTunnel(tun2socksProxyFromSessionJson(sessionJson))) {

--- a/apps/bibavpn-jni/Cargo.toml
+++ b/apps/bibavpn-jni/Cargo.toml
@@ -6,7 +6,7 @@ description = "JNI bridge: local SOCKS5 front for BibaVPN on Android"
 
 [lib]
 name = "bibavpn_jni"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1"

--- a/apps/bibavpn-jni/src/client_slot.rs
+++ b/apps/bibavpn-jni/src/client_slot.rs
@@ -1,0 +1,335 @@
+//! JNI client thread slot: idle, live, or stopping (shutdown sent, join pending).
+
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::thread::JoinHandle;
+use std::time::Duration;
+use tokio::sync::watch;
+
+/// How long stop / start-wait blocks before failing closed.
+pub const PRODUCTION_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug)]
+pub enum ClientSlot {
+    Live {
+        shutdown_tx: watch::Sender<bool>,
+        thread: JoinHandle<()>,
+        done_rx: Receiver<()>,
+    },
+    Stopping {
+        thread: JoinHandle<()>,
+        done_rx: Receiver<()>,
+    },
+}
+
+enum JoinWait {
+    Joined,
+    Timeout(ClientSlot),
+}
+
+fn wait_join(stopping: ClientSlot, timeout: Duration) -> JoinWait {
+    let ClientSlot::Stopping { thread, done_rx } = stopping else {
+        panic!("wait_join expects Stopping");
+    };
+    match done_rx.recv_timeout(timeout) {
+        // Sender dropped: thread body returned.
+        Err(RecvTimeoutError::Disconnected) => {
+            let _ = thread.join();
+            JoinWait::Joined
+        }
+        // Channel is never written to; timeout means thread still running.
+        Ok(()) | Err(RecvTimeoutError::Timeout) => {
+            tracing::warn!(
+                "stop: client thread still running after {:?}; keeping stopping slot (shutdown already signalled)",
+                timeout
+            );
+            JoinWait::Timeout(ClientSlot::Stopping { thread, done_rx })
+        }
+    }
+}
+
+/// Tracks at most one client thread and enforces bounded join on stop / start.
+pub struct ClientSlotManager {
+    slot: Option<ClientSlot>,
+    join_timeout: Duration,
+}
+
+impl ClientSlotManager {
+    pub fn new(join_timeout: Duration) -> Self {
+        Self {
+            slot: None,
+            join_timeout,
+        }
+    }
+
+    pub fn is_idle(&self) -> bool {
+        self.slot.is_none()
+    }
+
+    #[cfg(test)]
+    pub fn live_thread_count_for_test(&self) -> usize {
+        match &self.slot {
+            None => 0,
+            Some(ClientSlot::Live { thread, .. }) => {
+                if thread.is_finished() {
+                    0
+                } else {
+                    1
+                }
+            }
+            Some(ClientSlot::Stopping { thread, .. }) => {
+                if thread.is_finished() {
+                    0
+                } else {
+                    1
+                }
+            }
+        }
+    }
+
+    /// Prepare for a new client: wait out a stopping slot or join a dead live thread.
+    /// Returns `Err("already running")` if a thread is still alive after the bounded wait.
+    pub fn try_prepare_start(&mut self, clear_hook: impl Fn()) -> Result<(), &'static str> {
+        loop {
+            let Some(slot) = self.slot.take() else {
+                return Ok(());
+            };
+            match slot {
+                ClientSlot::Live {
+                    shutdown_tx,
+                    thread,
+                    done_rx,
+                } => {
+                    if !thread.is_finished() {
+                        self.slot = Some(ClientSlot::Live {
+                            shutdown_tx,
+                            thread,
+                            done_rx,
+                        });
+                        return Err("already running");
+                    }
+                    let _ = thread.join();
+                    drop(shutdown_tx);
+                    clear_hook();
+                }
+                ClientSlot::Stopping { thread, done_rx } => {
+                    match wait_join(ClientSlot::Stopping { thread, done_rx }, self.join_timeout)
+                    {
+                        JoinWait::Joined => clear_hook(),
+                        JoinWait::Timeout(stopping) => {
+                            self.slot = Some(stopping);
+                            return Err("already running");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn install_live(
+        &mut self,
+        shutdown_tx: watch::Sender<bool>,
+        thread: JoinHandle<()>,
+        done_rx: Receiver<()>,
+    ) {
+        self.slot = Some(ClientSlot::Live {
+            shutdown_tx,
+            thread,
+            done_rx,
+        });
+    }
+
+    /// Signal shutdown (if live), wait up to [`Self::join_timeout`], then join or keep stopping.
+    pub fn stop(&mut self, clear_hook: impl FnOnce()) {
+        let Some(slot) = self.slot.take() else {
+            return;
+        };
+        let stopping = match slot {
+            ClientSlot::Live {
+                shutdown_tx,
+                thread,
+                done_rx,
+            } => {
+                let _ = shutdown_tx.send(true);
+                ClientSlot::Stopping { thread, done_rx }
+            }
+            ClientSlot::Stopping { thread, done_rx } => ClientSlot::Stopping { thread, done_rx },
+        };
+        match wait_join(stopping, self.join_timeout) {
+            JoinWait::Joined => clear_hook(),
+            JoinWait::Timeout(stopping) => self.slot = Some(stopping),
+        }
+    }
+
+    /// Join a live slot after a failed start (e.g. SOCKS bind timeout). Same stopping semantics.
+    pub fn abort_pending_start(&mut self, clear_hook: impl FnOnce()) {
+        self.stop(clear_hook);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Instant;
+
+    const TEST_JOIN_TIMEOUT: Duration = Duration::from_millis(100);
+
+    fn spawn_dummy(sleep: Duration, shutdown: watch::Receiver<bool>) -> (JoinHandle<()>, Receiver<()>) {
+        let (done_tx, done_rx) = mpsc::channel::<()>();
+        let handle = thread::spawn(move || {
+            let _done_tx = done_tx;
+            let deadline = Instant::now() + sleep;
+            while Instant::now() < deadline {
+                if *shutdown.borrow() {
+                    return;
+                }
+                thread::sleep(Duration::from_millis(5));
+            }
+        });
+        (handle, done_rx)
+    }
+
+    fn spawn_ignore_shutdown(sleep: Duration) -> (JoinHandle<()>, Receiver<()>) {
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+        spawn_dummy(sleep, shutdown_rx)
+    }
+
+    #[test]
+    fn stop_timeout_leaves_stopping_slot() {
+        let hook_cleared = Arc::new(AtomicBool::new(false));
+        let hook_flag = hook_cleared.clone();
+        let mut mgr = ClientSlotManager::new(TEST_JOIN_TIMEOUT);
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let (thread, done_rx) = spawn_ignore_shutdown(Duration::from_secs(30));
+        mgr.install_live(shutdown_tx, thread, done_rx);
+
+        mgr.stop(|| hook_flag.store(true, Ordering::SeqCst));
+
+        assert!(!mgr.is_idle());
+        assert!(!hook_cleared.load(Ordering::SeqCst));
+        assert_eq!(mgr.live_thread_count_for_test(), 1);
+    }
+
+    #[test]
+    fn start_after_stop_timeout_fails_closed() {
+        let hook_cleared = Arc::new(AtomicBool::new(false));
+        let hook_flag = hook_cleared.clone();
+        let mut mgr = ClientSlotManager::new(TEST_JOIN_TIMEOUT);
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let (thread, done_rx) = spawn_ignore_shutdown(Duration::from_secs(30));
+        mgr.install_live(shutdown_tx, thread, done_rx);
+        mgr.stop(|| hook_flag.store(true, Ordering::SeqCst));
+        assert!(!mgr.is_idle());
+
+        let err = mgr.try_prepare_start(|| {}).unwrap_err();
+        assert_eq!(err, "already running");
+        assert_eq!(mgr.live_thread_count_for_test(), 1);
+        assert!(!hook_cleared.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn start_waits_for_stopping_thread_then_succeeds_once() {
+        let hook_cleared = Arc::new(AtomicBool::new(false));
+        let hook_flag = hook_cleared.clone();
+        let mut mgr = ClientSlotManager::new(Duration::from_millis(100));
+        let exit = Arc::new(AtomicBool::new(false));
+        let exit_flag = exit.clone();
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let (done_tx, done_rx) = mpsc::channel::<()>();
+        let thread = thread::spawn(move || {
+            let _done_tx = done_tx;
+            while !exit_flag.load(Ordering::SeqCst) {
+                thread::sleep(Duration::from_millis(5));
+            }
+        });
+        mgr.install_live(shutdown_tx, thread, done_rx);
+        mgr.stop(|| {});
+        assert!(!mgr.is_idle());
+
+        exit.store(true, Ordering::SeqCst);
+        assert!(
+            mgr.try_prepare_start(|| hook_flag.store(true, Ordering::SeqCst))
+                .is_ok()
+        );
+        assert!(hook_cleared.load(Ordering::SeqCst));
+
+        let (shutdown_tx2, _) = watch::channel(false);
+        let (thread2, done_rx2) = spawn_ignore_shutdown(Duration::from_millis(10));
+        mgr.install_live(shutdown_tx2, thread2, done_rx2);
+        assert_eq!(mgr.live_thread_count_for_test(), 1);
+    }
+
+    #[test]
+    fn stop_join_clears_slot_and_hook() {
+        let hook_cleared = Arc::new(AtomicBool::new(false));
+        let hook_flag = hook_cleared.clone();
+        let mut mgr = ClientSlotManager::new(TEST_JOIN_TIMEOUT);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let (thread, done_rx) = spawn_dummy(Duration::from_millis(10), shutdown_rx);
+        mgr.install_live(shutdown_tx, thread, done_rx);
+
+        mgr.stop(|| hook_flag.store(true, Ordering::SeqCst));
+
+        assert!(mgr.is_idle());
+        assert!(hook_cleared.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn start_after_successful_stop_succeeds() {
+        let mut mgr = ClientSlotManager::new(TEST_JOIN_TIMEOUT);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let (thread, done_rx) = spawn_dummy(Duration::from_millis(10), shutdown_rx);
+        mgr.install_live(shutdown_tx, thread, done_rx);
+        mgr.stop(|| {});
+
+        assert!(mgr.try_prepare_start(|| {}).is_ok());
+        let (shutdown_tx2, _) = watch::channel(false);
+        let (thread2, done_rx2) = spawn_ignore_shutdown(Duration::from_millis(10));
+        mgr.install_live(shutdown_tx2, thread2, done_rx2);
+        assert_eq!(mgr.live_thread_count_for_test(), 1);
+    }
+
+    #[test]
+    fn live_thread_still_running_rejects_start() {
+        let mut mgr = ClientSlotManager::new(TEST_JOIN_TIMEOUT);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let (thread, done_rx) = spawn_dummy(Duration::from_secs(30), shutdown_rx);
+        mgr.install_live(shutdown_tx, thread, done_rx);
+
+        let err = mgr.try_prepare_start(|| {}).unwrap_err();
+        assert_eq!(err, "already running");
+        assert_eq!(mgr.live_thread_count_for_test(), 1);
+    }
+
+    #[test]
+    fn never_two_live_threads() {
+        let mut mgr = ClientSlotManager::new(TEST_JOIN_TIMEOUT);
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let (thread, done_rx) = spawn_ignore_shutdown(Duration::from_secs(30));
+        mgr.install_live(shutdown_tx, thread, done_rx);
+
+        assert_eq!(mgr.live_thread_count_for_test(), 1);
+        assert_eq!(mgr.try_prepare_start(|| {}).unwrap_err(), "already running");
+        assert_eq!(mgr.live_thread_count_for_test(), 1);
+    }
+
+    #[test]
+    fn double_stop_on_stopping_waits_again() {
+        let hook_cleared = Arc::new(AtomicBool::new(false));
+        let hook_flag = hook_cleared.clone();
+        let mut mgr = ClientSlotManager::new(TEST_JOIN_TIMEOUT);
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let (thread, done_rx) = spawn_ignore_shutdown(Duration::from_secs(30));
+        mgr.install_live(shutdown_tx, thread, done_rx);
+        mgr.stop(|| {});
+        assert!(!mgr.is_idle());
+        assert!(!hook_cleared.load(Ordering::SeqCst));
+
+        mgr.stop(|| hook_flag.store(true, Ordering::SeqCst));
+        assert!(!mgr.is_idle());
+        assert!(!hook_cleared.load(Ordering::SeqCst));
+    }
+}

--- a/apps/bibavpn-jni/src/lib.rs
+++ b/apps/bibavpn-jni/src/lib.rs
@@ -1,70 +1,29 @@
 //! Android JNI: start/stop the embedded SOCKS5 → BibaVPN client (same protocol as `bibavpn-client`).
 
-use std::sync::{Arc, Mutex, OnceLock};
+mod client_slot;
 
-use anyhow::Context;
-use bibavpn::local_client::LocalClientOptions;
+use std::sync::{LazyLock, Mutex, OnceLock};
+
 use bibavpn::start_json_config::local_client_options_from_json_str;
 use bibavpn::tls_util::install_ring_crypto;
+use client_slot::{ClientSlotManager, PRODUCTION_JOIN_TIMEOUT};
 use jni::objects::{JClass, JString};
 use jni::sys::jstring;
 use jni::JNIEnv;
 use serde_json::json;
 use tokio::sync::watch;
 
-struct NativeState {
-    shutdown_tx: Option<watch::Sender<bool>>,
-    thread: Option<std::thread::JoinHandle<()>>,
-    /// Closed by the client thread's own sender when its body (and therefore the
-    /// tokio runtime drop) has finished. Gives [`stop_client_bounded`] the timed
-    /// join that `JoinHandle` does not offer.
-    done_rx: Option<std::sync::mpsc::Receiver<()>>,
+#[cfg(target_os = "android")]
+fn clear_outbound_protect_hook() {
+    bibavpn::outbound_protect::set_hook(None);
 }
 
-/// How long a stop waits for the client thread before detaching it.
-/// Mirrors the desktop bound in `ActiveVpn::stop` (`timeout(5s, handle)`).
-const STOP_JOIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+#[cfg(not(target_os = "android"))]
+fn clear_outbound_protect_hook() {}
 
-/// Signal shutdown and wait for the client thread, but never longer than
-/// [`STOP_JOIN_TIMEOUT`].
-///
-/// On Android this runs on the service teardown path, which reaches the main
-/// thread: an unbounded `join()` there is an ANR. Dropping the runtime waits for
-/// outstanding `spawn_blocking` work (e.g. `lookup_host`/getaddrinfo on a dead
-/// mobile network), so the wait has to be bounded. The shutdown signal has
-/// already been sent, so a detached thread still winds down on its own.
-fn stop_client_bounded(s: &mut NativeState) {
-    if let Some(tx) = s.shutdown_tx.take() {
-        let _ = tx.send(true);
-    }
-    let handle = s.thread.take();
-    let Some(rx) = s.done_rx.take() else {
-        // No completion channel (older state): fall back to a plain join.
-        if let Some(h) = handle {
-            let _ = h.join();
-        }
-        return;
-    };
-    match rx.recv_timeout(STOP_JOIN_TIMEOUT) {
-        // Sender dropped: the thread body returned, so `join` is immediate.
-        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-            if let Some(h) = handle {
-                let _ = h.join();
-            }
-        }
-        // Nobody ever sends on this channel; treat anything else as "still
-        // running" and detach rather than risk blocking the caller.
-        Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-            tracing::warn!(
-                "stop: client thread still running after {:?}; detaching (shutdown already signalled)",
-                STOP_JOIN_TIMEOUT
-            );
-            drop(handle);
-        }
-    }
-}
-
-static STATE: Mutex<Option<NativeState>> = Mutex::new(None);
+static STATE: LazyLock<Mutex<ClientSlotManager>> = LazyLock::new(|| {
+    Mutex::new(ClientSlotManager::new(PRODUCTION_JOIN_TIMEOUT))
+});
 
 static RING_ONCE: OnceLock<()> = OnceLock::new();
 static TRACING_ONCE: OnceLock<()> = OnceLock::new();
@@ -114,7 +73,6 @@ fn ensure_tracing() {
         }
         #[cfg(not(target_os = "android"))]
         {
-            use tracing_subscriber::util::SubscriberInitExt;
             let _ = tracing_subscriber::fmt()
                 .with_env_filter(
                     tracing_subscriber::EnvFilter::try_from_default_env()
@@ -271,23 +229,9 @@ pub extern "system" fn Java_dev_bibavpn_core_BibaNative_nativeStart(
         Err(_) => return jni_err(&mut env, "state mutex poisoned"),
     };
 
-    if guard.is_some() {
-        let thread_done = guard
-            .as_ref()
-            .and_then(|s| s.thread.as_ref().map(|t| t.is_finished()))
-            .unwrap_or(true);
-        if thread_done {
-            #[cfg(target_os = "android")]
-            {
-                bibavpn::outbound_protect::set_hook(None);
-            }
-            if let Some(mut s) = guard.take() {
-                stop_client_bounded(&mut s);
-            }
-        } else {
-            tracing::warn!("nativeStart: already running");
-            return jni_err(&mut env, "already running");
-        }
+    if let Err(msg) = guard.try_prepare_start(clear_outbound_protect_hook) {
+        tracing::warn!("nativeStart: {msg}");
+        return jni_err(&mut env, msg);
     }
 
     let opts = match local_client_options_from_json_str(&json) {
@@ -345,11 +289,7 @@ pub extern "system" fn Java_dev_bibavpn_core_BibaNative_nativeStart(
         }
     });
 
-    *guard = Some(NativeState {
-        shutdown_tx: Some(shutdown_tx),
-        thread: Some(thread),
-        done_rx: Some(done_rx),
-    });
+    guard.install_live(shutdown_tx, thread, done_rx);
     drop(guard);
 
     tracing::info!("nativeStart: waiting SOCKS bind (20s timeout)");
@@ -370,13 +310,7 @@ pub extern "system" fn Java_dev_bibavpn_core_BibaNative_nativeStart(
                 Ok(g) => g,
                 Err(_) => return jni_err(&mut env, msg),
             };
-            if let Some(mut s) = guard.take() {
-                stop_client_bounded(&mut s);
-            }
-            #[cfg(target_os = "android")]
-            {
-                bibavpn::outbound_protect::set_hook(None);
-            }
+            guard.abort_pending_start(clear_outbound_protect_hook);
             jni_err(&mut env, msg)
         }
     }
@@ -394,20 +328,12 @@ pub extern "system" fn Java_dev_bibavpn_core_BibaNative_nativeStop(
         Err(_) => return jni_err(&mut env, "state mutex poisoned"),
     };
 
-    let mut s = match guard.take() {
-        Some(s) => s,
-        None => {
-            tracing::info!("nativeStop: idle (no client)");
-            return std::ptr::null_mut();
-        }
-    };
-
-    stop_client_bounded(&mut s);
-
-    #[cfg(target_os = "android")]
-    {
-        bibavpn::outbound_protect::set_hook(None);
+    if guard.is_idle() {
+        tracing::info!("nativeStop: idle (no client)");
+        return std::ptr::null_mut();
     }
+
+    guard.stop(clear_outbound_protect_hook);
 
     tracing::info!("nativeStop: done");
     std::ptr::null_mut()


### PR DESCRIPTION
Closes #83

Automated agent-fix. Linked to issue #83. Draft — do not merge without a human review.

Review: PASS