### PR TITLE
ci: path-gated tests on PRs; apps and Docker only on main

### DIFF
--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -217,6 +217,8 @@ jobs:
           Automated agent-fix. Linked to issue #${n}. Draft — do not merge without a human review.
 
           Review: ${verdict}
+
+          Platform CI (Tests, Android, Desktop, iOS, Docker) starts when this PR is marked Ready for review. Agent fix already ran cargo test -p bibavpn -p biba.
           EOF
           )"
           gh pr create --draft --assignee "$GITHUB_ACTOR" --title "fix: ${title}" --body "$body"

--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -218,7 +218,7 @@ jobs:
 
           Review: ${verdict}
 
-          Platform CI (Tests, Android, Desktop, iOS, Docker) starts when this PR is marked Ready for review. Agent fix already ran cargo test -p bibavpn -p biba.
+          PR CI is Tests only, and only the jobs whose paths changed. Android, Desktop, iOS, and Docker build on push to main.
           EOF
           )"
           gh pr create --draft --assignee "$GITHUB_ACTOR" --title "fix: ${title}" --body "$body"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,4 +1,5 @@
 # Manual: Actions → Android → Run workflow. Also runs on push/PR when core VPN (protocol/server/client lib), JNI, or Tauri Android paths change.
+# Draft PRs skip this build (agent-fix). Mark Ready for review to run.
 name: Android
 
 run-name: Android · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
@@ -28,6 +29,7 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/android.yml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
     paths:
       - "bibavpn/**"
@@ -50,6 +52,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,5 +1,5 @@
-# Manual: Actions → Android → Run workflow. Also runs on push/PR when core VPN (protocol/server/client lib), JNI, or Tauri Android paths change.
-# Draft PRs skip this build (agent-fix). Mark Ready for review to run.
+# Manual: Actions → Android → Run workflow. Also runs on push to main when core
+# VPN, JNI, or Tauri Android paths change. Not on pull_request — tests live in test.yml.
 name: Android
 
 run-name: Android · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
@@ -28,23 +28,6 @@ on:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/android.yml"
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, master]
-    paths:
-      - "bibavpn/**"
-      - "!bibavpn/**/*.md"
-      - "biba/**"
-      - "!biba/**/*.md"
-      - "apps/bibavpn-jni/**"
-      - "!apps/bibavpn-jni/**/*.md"
-      - "apps/bibavpn-desktop/**"
-      - "!apps/bibavpn-desktop/**/*.md"
-      - "apps/scripts/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "rust-toolchain.toml"
-      - ".github/workflows/android.yml"
 
 concurrency:
   group: android-${{ github.ref }}
@@ -52,7 +35,6 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:

--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -1,4 +1,5 @@
 # Manual: Actions → Desktop Linux → Run workflow. Also runs on push/PR when core VPN library or desktop app paths change.
+# Draft PRs skip this build (agent-fix). Mark Ready for review to run.
 name: Desktop Linux
 
 run-name: Desktop Linux · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
@@ -26,6 +27,7 @@ on:
       - ".github/workflows/desktop-linux.yml"
       - ".github/scripts/ci-fetch-bypass-domains.sh"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
     paths:
       - "bibavpn/**"
@@ -46,6 +48,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -1,5 +1,5 @@
-# Manual: Actions → Desktop Linux → Run workflow. Also runs on push/PR when core VPN library or desktop app paths change.
-# Draft PRs skip this build (agent-fix). Mark Ready for review to run.
+# Manual: Actions → Desktop Linux → Run workflow. Also runs on push to main when
+# core VPN or desktop app paths change. Not on pull_request — tests live in test.yml.
 name: Desktop Linux
 
 run-name: Desktop Linux · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
@@ -26,21 +26,6 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/desktop-linux.yml"
       - ".github/scripts/ci-fetch-bypass-domains.sh"
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, master]
-    paths:
-      - "bibavpn/**"
-      - "!bibavpn/**/*.md"
-      - "biba/**"
-      - "!biba/**/*.md"
-      - "apps/bibavpn-desktop/**"
-      - "!apps/bibavpn-desktop/**/*.md"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "rust-toolchain.toml"
-      - ".github/workflows/desktop-linux.yml"
-      - ".github/scripts/ci-fetch-bypass-domains.sh"
 
 concurrency:
   group: desktop-linux-${{ github.ref }}
@@ -48,7 +33,6 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/desktop-macos.yml
+++ b/.github/workflows/desktop-macos.yml
@@ -1,5 +1,5 @@
-# Manual: Actions → Desktop macOS → Run workflow. Also runs on push/PR when core VPN library or desktop app paths change.
-# Draft PRs skip this build (agent-fix). Mark Ready for review to run.
+# Manual: Actions → Desktop macOS → Run workflow. Also runs on push to main when
+# core VPN or desktop app paths change. Not on pull_request — tests live in test.yml.
 name: Desktop macOS
 
 run-name: Desktop macOS · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
@@ -26,21 +26,6 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/desktop-macos.yml"
       - ".github/scripts/ci-fetch-bypass-domains.sh"
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, master]
-    paths:
-      - "bibavpn/**"
-      - "!bibavpn/**/*.md"
-      - "biba/**"
-      - "!biba/**/*.md"
-      - "apps/bibavpn-desktop/**"
-      - "!apps/bibavpn-desktop/**/*.md"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "rust-toolchain.toml"
-      - ".github/workflows/desktop-macos.yml"
-      - ".github/scripts/ci-fetch-bypass-domains.sh"
 
 concurrency:
   group: desktop-macos-${{ github.ref }}
@@ -48,7 +33,6 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: macos-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/desktop-macos.yml
+++ b/.github/workflows/desktop-macos.yml
@@ -1,4 +1,5 @@
 # Manual: Actions → Desktop macOS → Run workflow. Also runs on push/PR when core VPN library or desktop app paths change.
+# Draft PRs skip this build (agent-fix). Mark Ready for review to run.
 name: Desktop macOS
 
 run-name: Desktop macOS · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
@@ -26,6 +27,7 @@ on:
       - ".github/workflows/desktop-macos.yml"
       - ".github/scripts/ci-fetch-bypass-domains.sh"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
     paths:
       - "bibavpn/**"
@@ -46,6 +48,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: macos-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -1,4 +1,5 @@
 # Manual: Actions → Desktop Windows → Run workflow. Also runs on push/PR when core VPN library or desktop app paths change.
+# Draft PRs skip this build (agent-fix). Mark Ready for review to run.
 name: Desktop Windows
 
 run-name: Desktop Windows · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
@@ -26,6 +27,7 @@ on:
       - ".github/workflows/desktop-windows.yml"
       - ".github/scripts/ci-fetch-bypass-domains.sh"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
     paths:
       - "bibavpn/**"
@@ -46,6 +48,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: windows-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -1,5 +1,5 @@
-# Manual: Actions → Desktop Windows → Run workflow. Also runs on push/PR when core VPN library or desktop app paths change.
-# Draft PRs skip this build (agent-fix). Mark Ready for review to run.
+# Manual: Actions → Desktop Windows → Run workflow. Also runs on push to main when
+# core VPN or desktop app paths change. Not on pull_request — tests live in test.yml.
 name: Desktop Windows
 
 run-name: Desktop Windows · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
@@ -26,21 +26,6 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/desktop-windows.yml"
       - ".github/scripts/ci-fetch-bypass-domains.sh"
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, master]
-    paths:
-      - "bibavpn/**"
-      - "!bibavpn/**/*.md"
-      - "biba/**"
-      - "!biba/**/*.md"
-      - "apps/bibavpn-desktop/**"
-      - "!apps/bibavpn-desktop/**/*.md"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "rust-toolchain.toml"
-      - ".github/workflows/desktop-windows.yml"
-      - ".github/scripts/ci-fetch-bypass-domains.sh"
 
 concurrency:
   group: desktop-windows-${{ github.ref }}
@@ -48,7 +33,6 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: windows-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,11 +17,11 @@
 #                         eljaja/bibavpn-client repositories.
 #
 # Forks: this workflow only pushes when the event runs on the original
-# repository (i.e. where the secrets exist). PRs from forks build only.
+# repository (i.e. where the secrets exist).
 #
 # Path gating: workflow skips docs-only / desktop-only / app-only commits.
 # Per-image matrix: server and client images build independently when only one side changed.
-# Draft PRs skip image builds (agent-fix). Mark Ready for review to run.
+# Images build on push to main / tags / manual run — not on pull_request.
 name: Docker images
 
 on:
@@ -30,24 +30,6 @@ on:
       - main
     tags:
       - "v*"
-    paths:
-      - "bibavpn/**"
-      - "!bibavpn/**/*.md"
-      - "biba/**"
-      - "!biba/**/*.md"
-      - "docker/Dockerfile.server"
-      - "docker/Dockerfile.client"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "rust-toolchain.toml"
-      - "docker-compose.yml"
-      - "docker-compose.hub.yml"
-      - "docker-compose.bibavpn-check.yml"
-      - ".github/workflows/docker.yml"
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - main
     paths:
       - "bibavpn/**"
       - "!bibavpn/**/*.md"
@@ -73,7 +55,6 @@ concurrency:
 
 jobs:
   changes:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,7 @@
 #
 # Path gating: workflow skips docs-only / desktop-only / app-only commits.
 # Per-image matrix: server and client images build independently when only one side changed.
+# Draft PRs skip image builds (agent-fix). Mark Ready for review to run.
 name: Docker images
 
 on:
@@ -44,6 +45,7 @@ on:
       - "docker-compose.bibavpn-check.yml"
       - ".github/workflows/docker.yml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
     paths:
@@ -71,6 +73,7 @@ concurrency:
 
 jobs:
   changes:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
@@ -145,7 +148,7 @@ jobs:
 
   build-push:
     needs: changes
-    if: needs.changes.outputs.matrix != '[]'
+    if: needs.changes.result == 'success' && needs.changes.outputs.matrix != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,5 +1,5 @@
 # Cross-compile bibavpn-ffi for iOS (Rust ↔ Packet Tunnel static library).
-# Draft PRs skip this build (agent-fix). Mark Ready for review to run.
+# Push to main when FFI/core paths change. Not on pull_request — tests live in test.yml.
 name: iOS FFI
 
 run-name: iOS FFI · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
@@ -20,20 +20,6 @@ on:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/ios.yml"
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, master]
-    paths:
-      - "bibavpn/**"
-      - "!bibavpn/**/*.md"
-      - "biba/**"
-      - "!biba/**/*.md"
-      - "apps/bibavpn-ffi/**"
-      - "!apps/bibavpn-ffi/**/*.md"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "rust-toolchain.toml"
-      - ".github/workflows/ios.yml"
 
 concurrency:
   group: ios-ffi-${{ github.ref }}
@@ -41,7 +27,6 @@ concurrency:
 
 jobs:
   bibavpn-ffi-ios:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: macos-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,4 +1,5 @@
 # Cross-compile bibavpn-ffi for iOS (Rust ↔ Packet Tunnel static library).
+# Draft PRs skip this build (agent-fix). Mark Ready for review to run.
 name: iOS FFI
 
 run-name: iOS FFI · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
@@ -20,6 +21,7 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/ios.yml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
     paths:
       - "bibavpn/**"
@@ -39,6 +41,7 @@ concurrency:
 
 jobs:
   bibavpn-ffi-ios:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: macos-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,13 @@
-# Manual: Actions → Tests → Run workflow. Also runs on push/PR when Rust sources change.
+# Manual: Actions → Tests → Run workflow.
 #
 # The build workflows compile the crates but never `cargo test`, and `cargo build`
 # does not even type-check `#[cfg(test)]` code — so unit tests could break (or fail
 # to compile) unnoticed. Each job runs the tests on the platform where that crate is
 # already known to build: core crates on Linux (same as the Docker images),
 # bibavpn-desktop on Windows (same as Desktop Windows).
-# Draft PRs skip jobs (agent-fix opens drafts). Mark Ready for review to run.
+#
+# Jobs are path-gated: a protocol-only change does not start the Windows desktop
+# test runner. Unrelated paths do not start this workflow at all.
 name: Tests
 
 run-name: Tests · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
@@ -48,9 +50,56 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      core: ${{ steps.plan.outputs.core }}
+      desktop: ${{ steps.plan.outputs.desktop }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        id: filter
+        if: github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            core:
+              - 'bibavpn/**'
+              - '!bibavpn/**/*.md'
+              - 'biba/**'
+              - '!biba/**/*.md'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.github/workflows/test.yml'
+            desktop:
+              - 'apps/bibavpn-desktop/**'
+              - '!apps/bibavpn-desktop/**/*.md'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.github/workflows/test.yml'
+
+      - name: Plan which test jobs to run
+        id: plan
+        env:
+          FILTER_CORE: ${{ steps.filter.outputs.core }}
+          FILTER_DESKTOP: ${{ steps.filter.outputs.desktop }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "workflow_call" ]; then
+            echo "core=true" >> "$GITHUB_OUTPUT"
+            echo "desktop=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "core=${FILTER_CORE:-false}" >> "$GITHUB_OUTPUT"
+            echo "desktop=${FILTER_DESKTOP:-false}" >> "$GITHUB_OUTPUT"
+          fi
+
   core:
     name: cargo test (bibavpn, biba)
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: changes
+    if: needs.changes.outputs.core == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -69,7 +118,8 @@ jobs:
 
   desktop:
     name: cargo test (bibavpn-desktop)
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: changes
+    if: needs.changes.outputs.desktop == 'true'
     runs-on: windows-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@
 # to compile) unnoticed. Each job runs the tests on the platform where that crate is
 # already known to build: core crates on Linux (same as the Docker images),
 # bibavpn-desktop on Windows (same as Desktop Windows).
+# Draft PRs skip jobs (agent-fix opens drafts). Mark Ready for review to run.
 name: Tests
 
 run-name: Tests · ${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref_name }}
@@ -28,6 +29,7 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/test.yml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
     paths:
       - "bibavpn/**"
@@ -48,6 +50,7 @@ concurrency:
 jobs:
   core:
     name: cargo test (bibavpn, biba)
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -66,6 +69,7 @@ jobs:
 
   desktop:
     name: cargo test (bibavpn-desktop)
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: windows-latest
     timeout-minutes: 60
     env:


### PR DESCRIPTION
## Summary
- **PRs:** only the Tests workflow. `cargo test` (bibavpn/biba) runs if core paths changed; Windows `bibavpn-desktop` tests run only if the desktop app (or lockfile/toolchain) changed. Unrelated files start no runners.
- **main (and tags / manual / Release):** Android, Desktop, iOS FFI, and Docker still build, still path-gated. Docker still splits server vs client images.
- Agent-fix drafts no longer fan out seven platform workflows. They get Tests only when their diff actually touches those crates.

## Test plan
- [ ] Merge this so existing `agent/issue-*` drafts stop spawning Android/Desktop/iOS/Docker (GitHub uses workflows from the merge with `main`).
- [ ] Open or sync a protocol-only PR: Tests `changes` + Linux core, no Windows desktop job, no app/Docker workflows.
- [ ] Touch only `apps/bibavpn-desktop/ui`: Tests desktop job, no core cargo test.
- [ ] Docs-only commit: no Tests, no app builds.
- [ ] After merge to `main`, a core change still builds Docker + apps on `main`.