### PR TITLE
fix: Forward secrecy: fold the REALITY ephemeral DH into the transport key schedule

### DIFF
--- a/.github/agent/work/IMPLEMENT.md
+++ b/.github/agent/work/IMPLEMENT.md
@@ -1,0 +1,18 @@
+# Implementation
+
+REALITY + v3 PSK transport keys now mix the X25519 shared secret from the REALITY handshake into `transport_keys` via `SessionCrypto::new_with_reality_dh`. Non-REALITY `SessionCrypto::new` is unchanged.
+
+## Tests
+
+All spec test commands passed in this environment:
+
+- `cargo test -p bibavpn` — 189 tests (unit + integration)
+- `cargo test -p bibavpn --test reality_handshake` — 4 tests
+
+## Files changed
+
+- `bibavpn/src/crypto_layer.rs` — optional DH in `transport_keys`; `new_with_reality_dh`; unit tests
+- `bibavpn/src/udp_mux.rs` — retain REALITY DH; use `new_with_reality_dh` on REALITY path
+- `bibavpn/src/bin/server.rs` — thread REALITY `session_key` into `server_handshake_v3_after_first_hello`
+- `PROTOCOL.md` — REALITY + v3 key schedule and coordinated rollout
+- `AGENTS.md` — one-liner on REALITY + v3 transport key mixing

--- a/.github/agent/work/REVIEW.md
+++ b/.github/agent/work/REVIEW.md
@@ -1,0 +1,6 @@
+VERDICT: PASS
+
+- KDF matches SPEC: `transport_keys` keeps the PSK-only context; REALITY DH is appended as `u32be(32) || dh[32]` with the same `bibavpn.v3.c2s` / `bibavpn.v3.s2c` labels. `compute_mac` / `parse_ack` stay PSK-only.
+- `SessionCrypto::new` signature is unchanged. `new_with_reality_dh` is used only on REALITY+v3: client UDP mux keeps the `reality_client_exchange_verify` secret; server threads `server_handshake_reality`’s `session_key` into `server_handshake_v3_after_first_hello`.
+- Out-of-scope paths were left alone: non-REALITY `server_handshake_v3`, plaintext REALITY TCP mux (`bridge_ws_tcp_mux_server(..., None)`), `local_client.rs`, `biba/`, HELLO/ACK layout, CLI/invite.
+- Required unit tests (`reality_dh_changes_keys`, `reality_dh_same_roundtrip`, `reality_dh_vs_psk_only_mismatch`) are present and passed; `cargo test -p bibavpn` (including `reality_handshake`) passed. `PROTOCOL.md` / `AGENTS.md` document the key-schedule change and coordinated rollout. No secrets in the diff.

--- a/.github/agent/work/SPEC.md
+++ b/.github/agent/work/SPEC.md
@@ -1,0 +1,83 @@
+# Spec
+
+## Summary
+
+On the **REALITY + v3 PSK** path, mix the X25519 shared secret already returned by `reality_client_exchange_verify` / `server_handshake_reality` into `crypto_layer::transport_keys` so ChaCha20-Poly1305 session keys are not recoverable from PSK + public HELLO/ACK randoms alone.
+
+Today those 32-byte DH secrets are discarded (`_session_key` in `bibavpn/src/bin/server.rs` after REALITY AUTH, and the unused return of `reality_client_exchange_verify` in `bibavpn/src/udp_mux.rs`). `SessionCrypto::new` then derives `bibavpn.v3.c2s` / `bibavpn.v3.s2c` from PSK + proto-domain + `client_random` + `server_random` only. Those randoms are on the wire, so a later PSK leak decrypts captured REALITY+v3 sessions.
+
+This PR is a **coordinated client/server key-schedule change** for REALITY+v3 only. HELLO/ACK bytes and REALITY handshake frames stay the same (`REALITY_VERSION` remains 2). Mixed-version peers fail at the first sealed v3 frame (AUTH), not at HELLO/ACK. The non-REALITY PSK path must keep **byte-identical** transport keys.
+
+## In scope
+
+1. **KDF (private `transport_keys` in `bibavpn/src/crypto_layer.rs`)**
+   - Keep the current context when no REALITY DH is supplied (non-REALITY keys unchanged):
+     `u32be(psk.len) || psk || u32be(domain.len) || domain || client_random[32] || server_random[32]`
+     then `blake3::derive_key("bibavpn.v3.c2s" | "bibavpn.v3.s2c", ctx)`.
+   - When a REALITY shared secret is supplied, append `u32be(32) || dh[32]` to that same context. Do **not** invent new KDF labels. Do **not** fold DH into `bibavpn.v3.mac.psk` / ACK MAC (`compute_mac` / `parse_ack` stay PSK-only).
+   - DH input is the existing 32-byte X25519 shared secret from the REALITY handshake (already copied into `session_key` in `reality.rs`). Do not re-run DH.
+
+2. **`SessionCrypto` API**
+   - Keep `SessionCrypto::new(psk, domain, client_random, server_random, decoy_max)` as the PSK-only constructor (callers and keys unchanged).
+   - Add one constructor used only on REALITY+v3, e.g. `SessionCrypto::new_with_reality_dh(..., reality_dh: &[u8; 32])`, implemented by passing `Some(dh)` into `transport_keys`.
+
+3. **Thread DH into the REALITY+v3 SessionCrypto sites (both ends must pass the same secret)**
+   - **Client UDP mux** (`bibavpn/src/udp_mux.rs`): capture the `[u8; 32]` from `reality_client_exchange_verify` instead of discarding it; pass it to `new_with_reality_dh` when REALITY ran. If `reality_public_key` is absent, keep `SessionCrypto::new`.
+   - **Server** (`bibavpn/src/bin/server.rs`): keep the `Ok(session_key)` from `server_handshake_reality` (today `_session_key`). Pass it into `server_handshake_v3_after_first_hello` and construct crypto with `new_with_reality_dh`. The plaintext `MUX_OPEN` branch after REALITY is unchanged.
+
+4. **Docs (rollout)**
+   - `PROTOCOL.md`: under REALITY + v3 PSK (UDP mux / HELLO after REALITY), state that `c2s`/`s2c` also bind the REALITY X25519 shared secret; HELLO/ACK MAC does not; client and server must upgrade together; mixed versions fail at sealed AUTH.
+   - `AGENTS.md`: one sentence in the PSK / REALITY notes that REALITY+v3 mixes the ephemeral DH into transport keys (not ACK MAC). No CLI flags.
+
+## Out of scope
+
+- Wrapping **REALITY TCP mux** in `SessionCrypto` (plaintext `MUX_OPEN` after REALITY AUTH, `spawn_tcp_mux_client(..., None)` / `bridge_ws_tcp_mux_server(..., None)`). That path has no PSK-keyed data channel today; encrypting it is a larger wire change.
+- Changing REALITY HELLO / SERVER_HELLO / client AUTH layout or `REALITY_VERSION`.
+- Mixing DH into ACK MAC, AUTH token, or invite encoding.
+- Non-REALITY v3 (`one_try_wss_session`, `server_handshake_v3`).
+- New CLI flags, invite fields, or stealth/TLS changes.
+- Replacing X25519, adding double-ratchet / rekey, or encrypting the discarded TCP-mux `_session_key` without v3 HELLO.
+
+## Files to change
+
+- `bibavpn/src/crypto_layer.rs` — optional DH in `transport_keys`; new constructor; unit tests.
+- `bibavpn/src/udp_mux.rs` — keep REALITY DH; `SessionCrypto::new_with_reality_dh` on that path.
+- `bibavpn/src/bin/server.rs` — thread REALITY `session_key` into `server_handshake_v3_after_first_hello`.
+- `PROTOCOL.md` — REALITY+v3 key schedule + coordinated rollout.
+- `AGENTS.md` — matching one-liner.
+- `bibavpn/tests/tunnel_integration.rs` — only if `SessionCrypto::new` signature changes (prefer not to). Existing `session()` helper stays PSK-only.
+
+Do not touch `biba/`. `local_client.rs` REALITY TCP mux may keep discarding `_session_key` (out of scope).
+
+## Tests
+
+Run from repo root:
+
+```bash
+cargo test -p bibavpn
+cargo test -p bibavpn --test reality_handshake
+```
+
+Add unit tests in `bibavpn/src/crypto_layer.rs` (`#[cfg(test)]`), same seal/open style as `v3_domain_changes_keys`:
+
+- **DH changes keys:** same PSK, domain, and HELLO/ACK randoms; two different `reality_dh` values; ciphertext from one `new_with_reality_dh` must fail `open_*` on the other.
+- **Same DH roundtrips:** identical inputs including DH; `seal_client_to_server` / `open_client_to_server` (and s2c) succeed.
+- **DH vs PSK-only:** `new_with_reality_dh` ciphertext must not open on `SessionCrypto::new` with the same PSK/domain/randoms (and the reverse).
+- Existing `SessionCrypto::new` tests must keep passing (non-REALITY schedule unchanged).
+
+`reality_handshake.rs` stays handshake-only (shared-secret equality). Do not add a new live-server harness. `cargo test -p bibavpn` already runs `tests/tunnel_integration.rs` and `tests/smoke.rs`.
+
+## Acceptance criteria
+
+- With REALITY+v3, transport keys depend on the ephemeral DH: same PSK + same public randoms + different DH secrets produce different AEAD keys (unit test above).
+- Client and server REALITY+v3 UDP/HELLO paths both pass the handshake DH into `SessionCrypto`; omitting it on one side cannot decrypt.
+- Non-REALITY `SessionCrypto::new` keys are unchanged; existing v3 unit/integration tests pass.
+- `cargo test -p bibavpn` passes, including `--test reality_handshake` (TLS+WSS REALITY handshake).
+- `PROTOCOL.md` (and the `AGENTS.md` one-liner) document the key-schedule change and that client and server must ship together on the REALITY+v3 path.
+
+## Non-goals
+
+- Forward secrecy for plaintext REALITY TCP mux, or for the outer TLS layer.
+- Protection if the REALITY long-term private key is stolen (server DH is static; FS here is vs **PSK** compromise of captured v3 ciphertext).
+- Backward compatibility with old REALITY+v3 peers (this is an intentional break on that path only).
+- Performance work, new opcodes, or a second inner crypto version byte.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,9 @@ MAC is keyed BLAKE3 over `client_ephemeral_pub || server_pub` keyed by `shared_s
 frame existed the REALITY TCP path was an **open proxy**. The token is never sent on the wire; the
 server compares in constant time and records failures with the auth rate limiter, like a v3 AUTH
 mismatch. Adding a frame does not change the HELLO / SERVER_HELLO layout, so `REALITY_VERSION`
-stays `2` — but old and new peers no longer interoperate on the REALITY path.
+stays `2` — but old and new peers no longer interoperate on the REALITY path. On **REALITY + v3 PSK**,
+ChaCha20-Poly1305 transport keys also mix the REALITY X25519 shared secret (not the HELLO ACK MAC);
+client and server must ship together on that path.
 
 Typical traffic path (TCP, mux):
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -369,6 +369,14 @@ short-ID allowlist is permissive by default — see `--reality-short-ids`). Addi
 change the HELLO / SERVER_HELLO layout, so `REALITY_VERSION` stays **2**; older clients/servers fail
 the handshake immediately (breaking change on the REALITY path only).
 
+**REALITY + v3 PSK key schedule:** after the REALITY X25519 exchange, v3 `HELLO` / `ACK` and the
+HELLO ACK MAC are unchanged (PSK-only). ChaCha20-Poly1305 transport keys (`bibavpn.v3.c2s` /
+`bibavpn.v3.s2c`) additionally bind the 32-byte REALITY shared secret:
+`u32be(psk.len) || psk || u32be(domain.len) || domain || client_random || server_random ||
+u32be(32) || reality_dh`. Client and server **must upgrade together** on this path; a peer that omits
+the DH mix cannot decrypt sealed frames and fails at the first v3 `AUTH`. Non-REALITY v3 transport
+keys are unchanged.
+
 **Server CLI**
 
 ```bash

--- a/bibavpn/src/bin/server.rs
+++ b/bibavpn/src/bin/server.rs
@@ -887,6 +887,7 @@ async fn server_handshake_v3_after_first_hello<S>(
     psk: &str,
     decoy_max: u8,
     proto_domain: &str,
+    reality_dh: &[u8; 32],
     auth: &Arc<AuthRateLimiter>,
     stats: &Arc<ServerStats>,
     peer_ip: std::net::IpAddr,
@@ -901,11 +902,12 @@ where
     ws.send(Message::Binary(Bytes::from(ack)))
         .await
         .context("send v3 ACK (REALITY follow-up)")?;
-    let crypto = Arc::new(SessionCrypto::new(
+    let crypto = Arc::new(SessionCrypto::new_with_reality_dh(
         psk,
         proto_domain,
         &c,
         &s_rand,
+        reality_dh,
         decoy_max,
     ));
     let auth_c = Arc::clone(auth);
@@ -1205,14 +1207,15 @@ async fn handle_one(
         // application frame is honoured — otherwise this is an open proxy.
         // Bounded like the other pre-tunnel phases, but with its own arms: this
         // one is an auth step, so it also feeds the per-IP rate limiter.
-        match timeout(
+        let session_key = match timeout(
             handshake_timeout,
             server_handshake_reality(&mut ws, reality_cfg, &token),
         )
         .await
         {
-            Ok(Ok(_session_key)) => {
+            Ok(Ok(sk)) => {
                 auth.record_success(peer_ip).await;
+                sk
             }
             Ok(Err(e)) => {
                 auth.record_failure(peer_ip).await;
@@ -1229,7 +1232,7 @@ async fn handle_one(
                 auth.record_failure(peer_ip).await;
                 anyhow::bail!("handshake timeout waiting for REALITY AUTH");
             }
-        }
+        };
 
         let domain_trim = proto_domain.trim();
         if domain_trim.is_empty() {
@@ -1284,6 +1287,7 @@ async fn handle_one(
                 secret,
                 decoy_max,
                 domain_trim,
+                &session_key,
                 auth,
                 &params.stats,
                 peer_ip,

--- a/bibavpn/src/crypto_layer.rs
+++ b/bibavpn/src/crypto_layer.rs
@@ -66,15 +66,20 @@ fn transport_keys(
     domain: &str,
     client_random: &[u8; 32],
     server_random: &[u8; 32],
+    reality_dh: Option<&[u8; 32]>,
 ) -> ([u8; 32], [u8; 32]) {
     let d = domain.as_bytes();
-    let mut ctx = Vec::with_capacity(4 + psk.len() + 4 + d.len() + 64);
+    let mut ctx = Vec::with_capacity(4 + psk.len() + 4 + d.len() + 64 + 4 + 32);
     ctx.extend_from_slice(&(psk.len() as u32).to_be_bytes());
     ctx.extend_from_slice(psk);
     ctx.extend_from_slice(&(d.len() as u32).to_be_bytes());
     ctx.extend_from_slice(d);
     ctx.extend_from_slice(client_random);
     ctx.extend_from_slice(server_random);
+    if let Some(dh) = reality_dh {
+        ctx.extend_from_slice(&(32u32).to_be_bytes());
+        ctx.extend_from_slice(dh);
+    }
     let k_up = derive_key("bibavpn.v3.c2s", &ctx);
     let k_dn = derive_key("bibavpn.v3.s2c", &ctx);
     (k_up, k_dn)
@@ -172,7 +177,31 @@ impl SessionCrypto {
         server_random: &[u8; 32],
         decoy_max: u8,
     ) -> Self {
-        let (k_up, k_dn) = transport_keys(psk.as_bytes(), domain, client_random, server_random);
+        let (k_up, k_dn) =
+            transport_keys(psk.as_bytes(), domain, client_random, server_random, None);
+        Self {
+            c2s: ChaHalf::new(&k_up),
+            s2c: ChaHalf::new(&k_dn),
+            decoy_max,
+        }
+    }
+
+    /// REALITY + v3 PSK: transport keys also bind the X25519 shared secret from the REALITY handshake.
+    pub fn new_with_reality_dh(
+        psk: &str,
+        domain: &str,
+        client_random: &[u8; 32],
+        server_random: &[u8; 32],
+        reality_dh: &[u8; 32],
+        decoy_max: u8,
+    ) -> Self {
+        let (k_up, k_dn) = transport_keys(
+            psk.as_bytes(),
+            domain,
+            client_random,
+            server_random,
+            Some(reality_dh),
+        );
         Self {
             c2s: ChaHalf::new(&k_up),
             s2c: ChaHalf::new(&k_dn),
@@ -371,6 +400,59 @@ mod tests {
         let wire = enc.seal_client_to_server(b"plain").unwrap();
         let plain = enc.open_client_to_server(&wire).unwrap();
         assert_eq!(plain, b"plain");
+    }
+
+    #[test]
+    fn reality_dh_changes_keys() {
+        let psk = "same-psk";
+        let c = [3u8; 32];
+        let s = [4u8; 32];
+        let dom = "reality.example";
+        let dh_a = [0x11u8; 32];
+        let dh_b = [0x22u8; 32];
+        let a = SessionCrypto::new_with_reality_dh(psk, dom, &c, &s, &dh_a, 0);
+        let b = SessionCrypto::new_with_reality_dh(psk, dom, &c, &s, &dh_b, 0);
+        let inner = b"payload".to_vec();
+        let w = a.seal_client_to_server(&inner).unwrap();
+        assert!(b.open_client_to_server(&w).is_err());
+        let w2 = a.seal_server_to_client(&inner).unwrap();
+        assert!(b.open_server_to_client(&w2).is_err());
+    }
+
+    #[test]
+    fn reality_dh_same_roundtrip() {
+        let psk = "unit-test-psk";
+        let c = [1u8; 32];
+        let s = [2u8; 32];
+        let dom = "test.domain";
+        let dh = [0xabu8; 32];
+        let enc = SessionCrypto::new_with_reality_dh(psk, dom, &c, &s, &dh, 8);
+        let dec = SessionCrypto::new_with_reality_dh(psk, dom, &c, &s, &dh, 8);
+        let inner = b"padded-frame-blob".to_vec();
+        let wire = enc.seal_client_to_server(&inner).unwrap();
+        let out = dec.open_client_to_server(&wire).unwrap();
+        assert_eq!(out, inner);
+
+        let back = b"server-payload".to_vec();
+        let w2 = dec.seal_server_to_client(&back).unwrap();
+        let out2 = enc.open_server_to_client(&w2).unwrap();
+        assert_eq!(out2, back);
+    }
+
+    #[test]
+    fn reality_dh_vs_psk_only_mismatch() {
+        let psk = "psk";
+        let c = [5u8; 32];
+        let s = [6u8; 32];
+        let dom = "dom";
+        let dh = [0xccu8; 32];
+        let with_dh = SessionCrypto::new_with_reality_dh(psk, dom, &c, &s, &dh, 0);
+        let psk_only = SessionCrypto::new(psk, dom, &c, &s, 0);
+        let inner = b"x".to_vec();
+        let w = with_dh.seal_client_to_server(&inner).unwrap();
+        assert!(psk_only.open_client_to_server(&w).is_err());
+        let w2 = psk_only.seal_client_to_server(&inner).unwrap();
+        assert!(with_dh.open_client_to_server(&w2).is_err());
     }
 
     #[test]

--- a/bibavpn/src/udp_mux.rs
+++ b/bibavpn/src/udp_mux.rs
@@ -404,14 +404,18 @@ async fn connect_udp_mux_ws(
         .await
         .context("websocket")?;
 
-    if let Some(pk) = cfg.reality_public_key {
+    let reality_dh = if let Some(pk) = cfg.reality_public_key {
         let short_id = cfg
             .reality_short_id
             .unwrap_or_else(|| rand::random::<[u8; 8]>());
-        crate::reality::reality_client_exchange_verify(&mut ws, &pk, &short_id, &cfg.token)
-            .await
-            .context("REALITY handshake (udp mux)")?;
-    }
+        Some(
+            crate::reality::reality_client_exchange_verify(&mut ws, &pk, &short_id, &cfg.token)
+                .await
+                .context("REALITY handshake (udp mux)")?,
+        )
+    } else {
+        None
+    };
 
     send_noise_binaries(&mut ws, u32::from(cfg.early_ws_frames), cfg.max_ws_binary).await?;
     send_noise_binaries(&mut ws, cfg.junk_frames, cfg.max_ws_binary)
@@ -438,13 +442,23 @@ async fn connect_udp_mux_ws(
             Message::Binary(b) => {
                 let s_rand =
                     crypto_layer::parse_ack(secret, dom.as_str(), b.as_ref(), &c_rand)?;
-                let crypto = Arc::new(SessionCrypto::new(
-                    secret,
-                    dom.as_str(),
-                    &c_rand,
-                    &s_rand,
-                    cfg.decoy_max,
-                ));
+                let crypto = Arc::new(match reality_dh.as_ref() {
+                    Some(dh) => SessionCrypto::new_with_reality_dh(
+                        secret,
+                        dom.as_str(),
+                        &c_rand,
+                        &s_rand,
+                        dh,
+                        cfg.decoy_max,
+                    ),
+                    None => SessionCrypto::new(
+                        secret,
+                        dom.as_str(),
+                        &c_rand,
+                        &s_rand,
+                        cfg.decoy_max,
+                    ),
+                });
                 let mut udp_adaptive = AdaptivePadState::default();
                 let auth_inner = encode_v3_auth(&cfg.token).context("encode v3 AUTH (udp mux)")?;
                 let mut wire = Vec::new();


### PR DESCRIPTION
Closes #29

Automated agent-fix. Linked to issue #29. Draft — do not merge without a human review.

Review: PASS