### PR TITLE
fix: Handshake anti-replay: enforce timestamp + nonce (wire up max_time_diff)

### DIFF
--- a/.github/agent/work/REVIEW.md
+++ b/.github/agent/work/REVIEW.md
@@ -1,0 +1,7 @@
+VERDICT: PASS
+
+- HELLO v3 is 65 bytes (`version=3 || ephemeral:32 || short_id:8 || unix_secs BE || nonce:16`); `SERVER_HELLO` / AUTH frame layouts are unchanged except the version byte; `REALITY_VERSION` is 3.
+- AUTH MAC transcript is `client_ephemeral_pub || server_pub || unix_secs_be || nonce` with derive-key context `bibavpn reality client-auth v2`; confirm-MAC input is unchanged. MAC uses the HELLO fields parsed once (no re-read).
+- Server rejects short/wrong-version HELLO and timestamp skew (`|now - unix_secs| > max_time_diff`) before X25519; replay cache insert runs only after AUTH MAC verifies.
+- Process-wide `Arc<Mutex<…>>` cache stores `(nonce, hello_unix_secs)`, expires with `max_time_diff`, caps at 65536 (evict oldest timestamp). Built once in `bibavpn-server` when REALITY is on. CLI `--reality-max-time-diff-secs` default 90, range `1..=3600`; `max_time_diff` is no longer hardcoded to 0. Client sends `SystemTime` + `OsRng` nonce; no client flag.
+- Named unit and integration tests are present (wire/round-trip, window, MAC binding, cache duplicate/expiry/cap, happy path, captured-byte replay, stale vs in-window skew, wrong-token, missing AUTH). `TEST.log`: `cargo test -p bibavpn` 171 lib tests + `reality_handshake` 7/7 passed. Diff stays in the spec files; no proto-3 PSK AUTH, invite JSON, or secrets.

--- a/.github/agent/work/SPEC.md
+++ b/.github/agent/work/SPEC.md
@@ -1,0 +1,105 @@
+# Spec
+
+## Summary
+
+Wire up unused `RealityServerConfig.max_time_diff` so a captured REALITY handshake cannot be replayed.
+
+Today a REALITY client HELLO is `[version:1][ephemeral_x25519:32][short_id:8]` (`REALITY_VERSION = 2`). The mandatory AUTH MAC covers only the two public keys. An on-path observer can resend the same HELLO + AUTH bytes and the server derives the same X25519 shared secret and accepts the MAC.
+
+This PR extends the REALITY **client HELLO** with a unix timestamp and a random nonce, binds both into the AUTH MAC, rejects HELLO timestamps outside `±max_time_diff`, and remembers authenticated nonces for that window. Default window is **90 seconds**, exposed as a server flag. This is a breaking REALITY-path change: bump `REALITY_VERSION` to **3**.
+
+Do not change proto-3 PSK `AUTH` in this PR.
+
+## In scope
+
+1. **HELLO v3 layout** (fixed 65 bytes, big-endian timestamp):
+
+   `[version:1=0x03][client_ephemeral_x25519:32][short_id:8][unix_secs:u64 BE][nonce:16]`
+
+   `SERVER_HELLO` layout stays `[version:1][server_pub:32][confirm_mac:32]`; only the version byte becomes `3`. AUTH frame layout stays `[version:1][0xa1][mac:32]`; version byte becomes `3`.
+
+2. **Bind freshness into AUTH MAC.** Extend `reality_client_auth_mac` so the keyed BLAKE3 transcript is `client_ephemeral_pub || server_pub || unix_secs_be || nonce`. Bump the derive-key context from `bibavpn reality client-auth v1` to `bibavpn reality client-auth v2`. Confirm MAC / SERVER_HELLO transcript is unchanged aside from the version byte.
+
+3. **Server checks (in `server_handshake_reality`):**
+   - After parsing HELLO: reject wrong version / short frame; reject if `|now_unix_secs - unix_secs| > max_time_diff` with a clear error (mention timestamp / window). Do this **before** X25519.
+   - After AUTH MAC verifies: if the 16-byte nonce is already in the replay cache, reject with a clear replay error; otherwise insert. **Do not** insert on failed AUTH (unauthenticated HELLO must not fill the cache).
+   - Timestamp and nonce values used for the MAC **must** be the ones parsed from this HELLO (no re-read).
+
+4. **Replay cache:** process-wide, shared by all REALITY sessions (`Arc` + mutex). Store `(nonce, hello_unix_secs)`. On each check, drop entries with `hello_unix_secs + max_time_diff < now` (a replay after that would fail the timestamp check anyway). Cap at **65536** entries; if still full after expiry, evict the oldest `hello_unix_secs` then insert. Construct once in `bibavpn-server` when REALITY is enabled; pass into `server_handshake_reality`.
+
+5. **Default and CLI.** Default `max_time_diff` is **90** seconds (not `0`). Add `bibavpn-server --reality-max-time-diff-secs` (u64, default 90, allowed range **1..=3600**). Reject `0` at clap / startup — do not treat `0` as “disable”. Set `RealityServerConfig.max_time_diff` from this flag. Client always sends `SystemTime` unix seconds and 16 random bytes (`OsRng`); no client flag.
+
+6. **Docs:** `PROTOCOL.md` REALITY section (HELLO bytes, version 3, MAC transcript, incompatibility with v2), `AGENTS.md` version note, `README.md` one-line CLI mention next to the other REALITY flags.
+
+## Out of scope
+
+- Proto-3 PSK sealed `AUTH` timestamp / nonce (wishlist leftover; separate PR).
+- Changing `SERVER_HELLO` fields or `reality_confirm_mac` input.
+- Persisting the nonce cache across process restart.
+- Client / invite JSON field for `max_time_diff`.
+- Disabling anti-replay (`max_time_diff = 0`).
+- NTP / clock-sync helpers; operators must have roughly aligned unix time.
+- Xray TLS ClientHello REALITY, JNI/Tauri/UI toggles, metrics counters for replays.
+
+## Files to change
+
+- `bibavpn/src/reality.rs` — `REALITY_VERSION = 3`; HELLO encode/decode; AUTH MAC transcript + context string; `RealityReplayCache`; enforce window + nonce in `server_handshake_reality`; client `reality_client_exchange_verify` / `encode_client_hello`; existing `#[cfg(test)]` layout and MAC tests.
+- `bibavpn/src/lib.rs` — re-export new HELLO helpers / cache type if the integration test needs them (keep the public surface small).
+- `bibavpn/src/bin/server.rs` — `--reality-max-time-diff-secs`; stop hardcoding `max_time_diff: 0`; one shared cache; pass it into `server_handshake_reality`.
+- `bibavpn/tests/reality_handshake.rs` — happy path with v3 HELLO; replay of captured bytes; skew inside vs outside window; `max_time_diff: 90` (or the value under test) instead of `0`.
+- `PROTOCOL.md`, `AGENTS.md`, `README.md` — wire + CLI as above.
+
+Call-site note: `server_handshake_reality` is only used from `bin/server.rs` and `tests/reality_handshake.rs`. `encode_client_hello` / `reality_client_auth_mac` call sites in this crate must be updated to the new signatures.
+
+Suggested helpers (names can vary, behavior must not):
+
+- `encode_client_hello(short_id, client_pubkey, unix_secs, nonce: &[u8; 16]) -> Vec<u8>`
+- `decode_client_hello(&[u8]) -> Result<…>` (version, pubkey, short_id, unix_secs, nonce)
+- `reality_timestamp_in_window(now: u64, unix_secs: u64, max_time_diff: u64) -> Result<()>`
+- `RealityReplayCache::check_and_insert(nonce, hello_unix_secs, now, max_time_diff) -> Result<()>`
+
+Inject `now` in unit tests; production handshake uses current unix seconds.
+
+## Tests
+
+Run:
+
+```bash
+cargo test -p bibavpn
+cargo test -p bibavpn --test reality_handshake
+```
+
+Add/extend tests in `bibavpn/src/reality.rs` (`#[cfg(test)]`) and `bibavpn/tests/reality_handshake.rs`. No new harness.
+
+Unit (`reality.rs`):
+
+- HELLO wire is 65 bytes, version `3`, round-trip decode.
+- Short / wrong-version HELLO fails.
+- `reality_timestamp_in_window`: `|delta| <= max_time_diff` ok; `max_time_diff + 1` both past and future fail.
+- AUTH MAC matches for the same `(token, keys, unix_secs, nonce)` and differs if timestamp or nonce changes.
+- Replay cache: first insert ok; same nonce rejected; nonce accepted again after `hello_unix_secs + max_time_diff < now`; inserting past the cap does not grow unbounded (len ≤ 65536).
+- Existing confirm-MAC / wrong-token / cross-session AUTH tests updated to the new MAC signature.
+
+Integration (`reality_handshake.rs`):
+
+- Current happy path still succeeds (client `reality_client_exchange_verify` vs `server_handshake_reality`) with a shared cache and `max_time_diff: 90`.
+- Capture HELLO + AUTH bytes from a successful handshake (or build them with `encode_client_hello` / `encode_client_auth`); send the **same bytes** on a second connection to a server that still holds the cache → server `Err` (replay).
+- HELLO with `unix_secs = now - max_time_diff - 1` → server `Err` whose message is clearly about time / window; skew of `max_time_diff` (or a few seconds inside it) still succeeds.
+- Existing wrong-token and missing-AUTH cases still fail.
+
+## Acceptance criteria
+
+- A replayed REALITY handshake (exact captured HELLO + AUTH resent while the nonce is still in the window) is rejected by the server.
+- Clock skew with `|now - unix_secs| <= max_time_diff` succeeds; outside that window fails with a clear timestamp/window error (no token/PSK in logs).
+- Seen-nonce set is a sliding window, expires with `max_time_diff`, and is capped (65536).
+- Default window is 90s via `--reality-max-time-diff-secs`; `RealityServerConfig.max_time_diff` is no longer stuck at `0` and is actually read.
+- v2 REALITY peers fail immediately on version mismatch (`REALITY_VERSION = 3`).
+- `cargo test -p bibavpn` and `cargo test -p bibavpn --test reality_handshake` pass.
+
+## Non-goals
+
+- Anti-replay for proto-3 PSK `AUTH` / `HELLO`.
+- Compatibility with `REALITY_VERSION` 2 on the REALITY path.
+- Surviving nonce-cache loss on server restart (a replay whose timestamp is still in-window could succeed until the new cache fills; accepted limitation).
+- Hiding REALITY as Xray TLS-hook REALITY, or any DPI/fingerprint work.
+- New metrics, log targets, or invite fields.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,13 +106,14 @@ logs a `WARN` at startup). Client / invite: `reality_target`,
 non-REALITY). Test: `cargo test -p bibavpn --test reality_handshake`.
 
 **REALITY client AUTH is required** in every REALITY session, on both the `MUX_OPEN` and the
-REALITY + v3 (UDP mux) sub-paths: `[version:1][0xa1][mac:32]` right after `SERVER_HELLO`, where the
-MAC is keyed BLAKE3 over `client_ephemeral_pub || server_pub` keyed by `shared_secret || token`
-(`reality_client_auth_mac`). The X25519 exchange only authenticates the **server**, so before this
-frame existed the REALITY TCP path was an **open proxy**. The token is never sent on the wire; the
-server compares in constant time and records failures with the auth rate limiter, like a v3 AUTH
-mismatch. Adding a frame does not change the HELLO / SERVER_HELLO layout, so `REALITY_VERSION`
-stays `2` — but old and new peers no longer interoperate on the REALITY path.
+REALITY + v3 (UDP mux) sub-paths: `[version:1=0x03][0xa1][mac:32]` right after `SERVER_HELLO`, where the
+MAC is keyed BLAKE3 over `client_ephemeral_pub || server_pub || unix_secs_be || nonce` keyed by
+`shared_secret || token` (`reality_client_auth_mac`). The X25519 exchange only authenticates the **server**,
+so before this frame existed the REALITY TCP path was an **open proxy**. The token is never sent on the wire;
+the server compares in constant time and records failures with the auth rate limiter, like a v3 AUTH
+mismatch. Client HELLO v3 adds a unix timestamp and 16-byte nonce; the server rejects skew outside
+`±max_time_diff` (default **90 s**, `--reality-max-time-diff-secs`) and replays of seen nonces.
+**`REALITY_VERSION` is 3** — v2 REALITY peers no longer interoperate.
 
 Typical traffic path (TCP, mux):
 
@@ -225,7 +226,7 @@ the mux record header when chunking TCP).
 - `--early-ws-frames`, `--junk-frames`
 - `--pin-cert` (client) — incompatible with `--insecure`; supported on **rustls** and **boring** (`boring-tls` build)
 - `--reality-target`, `--reality-public-key`, `--reality-short-id` (client) — WSS REALITY front mode; invite JSON mirrors these fields
-- Server **REALITY:** `--reality-target vk.com:443`, `--reality-private-key` (base64 X25519 seed, 32 bytes), `--reality-short-ids` (hex, comma-separated; empty = any + startup `WARN`; all-zero entry = wildcard + startup `WARN`), `--reality-server-names` (optional SNI allowlist; default = host from target). `--token` is **required** on the REALITY path too: it keys the client AUTH MAC.
+- Server **REALITY:** `--reality-target vk.com:443`, `--reality-private-key` (base64 X25519 seed, 32 bytes), `--reality-short-ids` (hex, comma-separated; empty = any + startup `WARN`; all-zero entry = wildcard + startup `WARN`), `--reality-server-names` (optional SNI allowlist; default = host from target), `--reality-max-time-diff-secs` (default **90**, range 1..=3600 — HELLO timestamp skew and nonce replay window). `--token` is **required** on the REALITY path too: it keys the client AUTH MAC.
 - `--ws-path` / server `--ws-path` — WebSocket path; token via `AUTH`
 (default `/ws`)
 - Client `--proto` (only `**3`** is supported) and `--proto-domain` (KDF label;

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -351,23 +351,24 @@ on your VPS.
 
 1. Client → VPS: **TLS** (SNI = front domain from `reality_target`) + **WSS** upgrade on `--ws-path`.
 2. **REALITY binary exchange** on the WebSocket (before v3 PSK on this path):
-   - Client → server: `[version:1][client_ephemeral_x25519:32][short_id:8]`
-   - Server → client: `[version:1][server_long_term_x25519:32][confirm_mac:32]` — the pubkey must
+   - Client → server: `[version:1=0x03][client_ephemeral_x25519:32][short_id:8][unix_secs:u64 BE][nonce:16]` (65 bytes fixed)
+   - Server → client: `[version:1=0x03][server_long_term_x25519:32][confirm_mac:32]` — the pubkey must
      match invite `reality_public_key`, and the MAC (keyed BLAKE3 over both pubkeys, keyed by the
      X25519 shared secret) proves the server holds the private key.
-3. **Mandatory client AUTH** (`[version:1][0xa1][mac:32]`): keyed BLAKE3 over
-   `client_ephemeral_pub || server_pub`, keyed by `shared_secret || token`. The **token never goes on
-   the wire** and the MAC is bound to this handshake, so it cannot be replayed into another session.
-   The server compares in constant time and **drops the connection before any application frame** if
-   it does not match (counted by the auth rate limiter / ban list like a v3 AUTH failure).
+3. **Mandatory client AUTH** (`[version:1=0x03][0xa1][mac:32]`): keyed BLAKE3 over
+   `client_ephemeral_pub || server_pub || unix_secs_be || nonce`, keyed by `shared_secret || token`.
+   The **token never goes on the wire**; the MAC binds this handshake transcript including freshness,
+   and the server rejects HELLO timestamps outside `±max_time_diff` (default **90 s**) and replays
+   of the same nonce while it remains in the sliding window. The server compares in constant time and
+   **drops the connection before any application frame** if the MAC does not match (counted by the
+   auth rate limiter / ban list like a v3 AUTH failure).
 4. Client sends plaintext **`MUX_OPEN`**; mux streams carry target TCP (no v3 HELLO/AUTH on this path).
 
 Step 3 is **required in every REALITY session**, including the REALITY + v3 PSK (UDP mux) path where
 a v3 `HELLO` follows instead of `MUX_OPEN`. REALITY itself authenticates only the *server*; without
 this step anyone able to reach the port and complete the WSS upgrade would get full proxying (the
-short-ID allowlist is permissive by default — see `--reality-short-ids`). Adding the frame does not
-change the HELLO / SERVER_HELLO layout, so `REALITY_VERSION` stays **2**; older clients/servers fail
-the handshake immediately (breaking change on the REALITY path only).
+short-ID allowlist is permissive by default — see `--reality-short-ids`). **`REALITY_VERSION` is 3**;
+v2 peers fail immediately on version mismatch (breaking change on the REALITY path only).
 
 **Server CLI**
 
@@ -376,6 +377,7 @@ bibavpn-server \
   --reality-target 'vk.com:443' \
   --reality-private-key "$REALITY_PRIV_B64" \
   --reality-short-ids '0123456789abcdef'   # optional; omit = any; 000…000 = wildcard
+  --reality-max-time-diff-secs 90            # default 90; allowed 1..=3600
 ```
 
 Omitting `--reality-short-ids` (or listing `0000000000000000`) accepts **any** short ID; the server

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Every CLI flag is documented in **[AGENTS.md](AGENTS.md)**. Essentials:
 - **Camouflage (server):** `--camouflage-dir <path>` or `--camouflage-url http://…`.
 - **TLS trust (client):** real CA by default, `--pin-cert <pem>` to pin the leaf,
   `--insecure` **lab only**.
-- **REALITY (optional):** server `--reality-target`, `--reality-private-key`;
+- **REALITY (optional):** server `--reality-target`, `--reality-private-key`,
+  `--reality-max-time-diff-secs` (default 90 s HELLO skew / replay window);
   client/invite `reality_target`, `reality_public_key`, `reality_short_id`. The
   outer SNI then defaults to the front host (`vk.com:443` → SNI `vk.com`) while
   TCP still connects to `--server`. The client must also prove knowledge of

--- a/bibavpn/src/bin/server.rs
+++ b/bibavpn/src/bin/server.rs
@@ -27,7 +27,7 @@ use bibavpn::ServerWsOutTiming;
 use bibavpn::{read_padded_frame_into, write_padded_frame_with_mode_state};
 use bibavpn::tls_util::{install_ring_crypto, server_config_from_pem, server_self_signed};
 use bibavpn::ws_bridge::TunnelEnd;
-use bibavpn::reality::{extract_sni, server_handshake_reality, RealityServerConfig};
+use bibavpn::reality::{extract_sni, server_handshake_reality, RealityReplayCache, RealityServerConfig};
 use base64::Engine;
 use bytes::Bytes;
 use clap::Parser;
@@ -262,6 +262,10 @@ struct Args {
     /// REALITY mode: server names for SNI (comma-separated). Default: extracted from target.
     #[arg(long)]
     reality_server_names: Option<String>,
+
+    /// REALITY mode: max allowed HELLO timestamp skew in seconds (default 90; 1..=3600).
+    #[arg(long, default_value_t = 90, value_parser = clap::value_parser!(u64).range(1..=3600))]
+    reality_max_time_diff_secs: u64,
 }
 
 type SharedCrypto = Arc<SessionCrypto>;
@@ -633,8 +637,14 @@ async fn main() -> anyhow::Result<()> {
             short_ids,
             min_client_ver: None,
             max_client_ver: None,
-            max_time_diff: 0,
+            max_time_diff: args.reality_max_time_diff_secs,
         })
+    } else {
+        None
+    };
+
+    let reality_replay_cache: Option<Arc<RealityReplayCache>> = if reality_config.is_some() {
+        Some(Arc::new(RealityReplayCache::new()))
     } else {
         None
     };
@@ -762,6 +772,7 @@ async fn main() -> anyhow::Result<()> {
         let psk_conn = psk.clone();
         let proto_domain = args.proto_domain.clone();
         let reality_cfg = reality_config.clone();
+        let reality_replay = reality_replay_cache.clone();
         let server_ws_out = server_ws_out;
         let auth = Arc::clone(&auth);
         let stats = Arc::clone(&stats);
@@ -841,6 +852,7 @@ async fn main() -> anyhow::Result<()> {
                 camo,
                 proto_domain,
                 reality_cfg,
+                reality_replay,
                 params,
             )
             .await
@@ -1136,6 +1148,7 @@ async fn handle_one(
     camo: CamouflageServeConfig,
     proto_domain: String,
     reality_config: Option<RealityServerConfig>,
+    reality_replay_cache: Option<Arc<RealityReplayCache>>,
     params: ServerConnParams,
 ) -> anyhow::Result<()> {
     let span = tracing::info_span!(
@@ -1207,7 +1220,14 @@ async fn handle_one(
         // one is an auth step, so it also feeds the per-IP rate limiter.
         match timeout(
             handshake_timeout,
-            server_handshake_reality(&mut ws, reality_cfg, &token),
+            server_handshake_reality(
+                &mut ws,
+                reality_cfg,
+                &token,
+                reality_replay_cache
+                    .as_ref()
+                    .expect("REALITY replay cache"),
+            ),
         )
         .await
         {

--- a/bibavpn/src/lib.rs
+++ b/bibavpn/src/lib.rs
@@ -46,15 +46,15 @@ pub use frame::{
 };
 pub use invite_uri::{decode_invite_v1, encode_invite_v1, InviteV1};
 pub use reality::{
-    decode_client_auth, decode_server_hello, effective_tls_sni, encode_client_auth,
-    encode_client_hello, extract_sni,
+    decode_client_auth, decode_client_hello, decode_server_hello, effective_tls_sni,
+    encode_client_auth, encode_client_hello, extract_sni,
     is_short_id_allowed, parse_target, create_tls_connector, reality_client_auth_mac,
     reality_client_exchange_verify,
-    reality_confirm_mac, server_handshake_reality, server_hello_with_confirm,
-    server_hello_with_confirm_and_shared,
-    RealityClientConfig, RealityServerConfig,
-    REALITY_CLIENT_AUTH_LEN, REALITY_CLIENT_AUTH_TAG, REALITY_MAGIC, REALITY_VERSION,
-    spiderx_fetch, spawn_spiderx, TlsFingerprint,
+    reality_confirm_mac, reality_timestamp_in_window, server_handshake_reality,
+    server_hello_with_confirm, server_hello_with_confirm_and_shared, RealityClientHello,
+    RealityClientConfig, RealityReplayCache, RealityServerConfig,
+    REALITY_CLIENT_AUTH_LEN, REALITY_CLIENT_AUTH_TAG, REALITY_CLIENT_HELLO_LEN,
+    REALITY_MAGIC, REALITY_VERSION, spiderx_fetch, spawn_spiderx, TlsFingerprint,
 };
 pub use start_json_config::{
     local_client_options_from_json_str, local_client_options_from_json_str_with_binds,

--- a/bibavpn/src/reality.rs
+++ b/bibavpn/src/reality.rs
@@ -13,12 +13,13 @@
 //!
 //! SpiderX background fetches keep server-side camouflage warm against the REALITY target.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{bail, Context};
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
-use rand::Rng;
+use rand::{Rng, RngCore};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::DigitallySignedStruct;
 use subtle::ConstantTimeEq;
@@ -33,21 +34,23 @@ use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
 
 /// REALITY protocol magic bytes (reserved for future wire extensions).
 pub const REALITY_MAGIC: &[u8] = b"REAL1";
-/// Wire version. v2 adds a server confirmation MAC to SERVER_HELLO so the
-/// server proves possession of the REALITY private key (v1 only echoed the
-/// pinned public key, which a MITM that knows it could trivially replay).
-/// v2 is intentionally incompatible with v1 on both ends.
-///
-/// The mandatory client AUTH frame is an **added** frame after SERVER_HELLO and
-/// does not change the HELLO / SERVER_HELLO layout, so the version stays at 2;
-/// a peer that omits or mis-frames it is rejected on the spot anyway.
-pub const REALITY_VERSION: u8 = 2;
+/// Wire version. v2 adds a server confirmation MAC to SERVER_HELLO. v3 extends
+/// client HELLO with a unix timestamp and nonce, binds both into the AUTH MAC,
+/// and rejects replays within `max_time_diff`. Incompatible with v2 on both ends.
+pub const REALITY_VERSION: u8 = 3;
+
+/// Fixed wire size of client HELLO v3:
+/// `[version][ephemeral:32][short_id:8][unix_secs:8 BE][nonce:16]`.
+pub const REALITY_CLIENT_HELLO_LEN: usize = 1 + 32 + 8 + 8 + 16;
 
 /// BLAKE3 derive-key context for the REALITY handshake confirmation MAC.
 const REALITY_CONFIRM_CONTEXT: &str = "bibavpn reality server-confirm v2";
 
 /// BLAKE3 derive-key context for the mandatory client AUTH MAC.
-const REALITY_CLIENT_AUTH_CONTEXT: &str = "bibavpn reality client-auth v1";
+const REALITY_CLIENT_AUTH_CONTEXT: &str = "bibavpn reality client-auth v2";
+
+/// Max seen nonces retained in the process-wide REALITY replay cache.
+const REALITY_REPLAY_CACHE_CAP: usize = 65536;
 
 /// Frame tag of the client AUTH frame (byte 1, after the version byte).
 pub const REALITY_CLIENT_AUTH_TAG: u8 = 0xa1;
@@ -73,9 +76,9 @@ pub fn reality_confirm_mac(
 }
 
 /// Client AUTH MAC over the handshake transcript, keyed by the X25519 shared
-/// secret **and** the session token. The token never touches the wire, and the
-/// MAC is bound to both public keys, so it cannot be replayed into another
-/// session (different ephemeral key → different shared secret → different MAC).
+/// secret **and** the session token. The token never touches the wire. The MAC
+/// binds both public keys plus the HELLO timestamp and nonce so a captured
+/// handshake cannot be replayed within `max_time_diff`.
 ///
 /// The X25519 exchange alone only authenticates the *server*
 /// (see `reality_confirm_mac`); this MAC is what authenticates the *client*.
@@ -84,6 +87,8 @@ pub fn reality_client_auth_mac(
     token: &str,
     client_ephemeral_pub: &[u8; 32],
     server_static_pub: &[u8; 32],
+    unix_secs: u64,
+    nonce: &[u8; 16],
 ) -> [u8; 32] {
     // Key material = shared secret || token. `shared` is fixed-width, so the
     // concatenation is unambiguous. Knowing only one of the two is not enough.
@@ -94,7 +99,89 @@ pub fn reality_client_auth_mac(
     let mut h = blake3::Hasher::new_keyed(&mac_key);
     h.update(client_ephemeral_pub);
     h.update(server_static_pub);
+    h.update(&unix_secs.to_be_bytes());
+    h.update(nonce);
     *h.finalize().as_bytes()
+}
+
+/// Parsed REALITY client HELLO v3.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RealityClientHello {
+    pub client_pubkey: [u8; 32],
+    pub short_id: [u8; 8],
+    pub unix_secs: u64,
+    pub nonce: [u8; 16],
+}
+
+/// Returns true when `|now - unix_secs| <= max_time_diff`.
+pub fn reality_timestamp_in_window(
+    now: u64,
+    unix_secs: u64,
+    max_time_diff: u64,
+) -> anyhow::Result<()> {
+    let delta = now.abs_diff(unix_secs);
+    if delta > max_time_diff {
+        bail!(
+            "REALITY: HELLO timestamp outside allowed window (skew {delta}s > max_time_diff {max_time_diff}s)"
+        );
+    }
+    Ok(())
+}
+
+/// Process-wide sliding-window cache of authenticated HELLO nonces.
+#[derive(Debug, Default)]
+pub struct RealityReplayCache {
+    inner: Mutex<RealityReplayCacheInner>,
+}
+
+#[derive(Debug, Default)]
+struct RealityReplayCacheInner {
+    entries: Vec<([u8; 16], u64)>,
+}
+
+impl RealityReplayCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Reject if `nonce` was already authenticated within the sliding window;
+    /// otherwise insert. Expired entries are dropped first.
+    pub fn check_and_insert(
+        &self,
+        nonce: &[u8; 16],
+        hello_unix_secs: u64,
+        now: u64,
+        max_time_diff: u64,
+    ) -> anyhow::Result<()> {
+        let mut guard = self.inner.lock().expect("REALITY replay cache mutex");
+        guard
+            .entries
+            .retain(|(_, ts)| ts.saturating_add(max_time_diff) >= now);
+
+        if guard.entries.iter().any(|(seen, _)| seen == nonce) {
+            bail!("REALITY: replay detected (HELLO nonce already seen)");
+        }
+
+        if guard.entries.len() >= REALITY_REPLAY_CACHE_CAP {
+            if let Some(idx) = guard
+                .entries
+                .iter()
+                .enumerate()
+                .min_by_key(|(_, (_, ts))| *ts)
+                .map(|(i, _)| i)
+            {
+                guard.entries.remove(idx);
+            }
+        }
+
+        guard.entries.push((*nonce, hello_unix_secs));
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.inner.lock().expect("REALITY replay cache mutex").entries.len()
+    }
 }
 
 /// Wire bytes for the client AUTH frame: `[version][tag][mac:32]`.
@@ -364,30 +451,27 @@ pub async fn server_handshake_reality<S>(
     ws: &mut WebSocketStream<S>,
     cfg: &RealityServerConfig,
     token: &str,
+    replay_cache: &RealityReplayCache,
 ) -> anyhow::Result<[u8; 32]>
 where
     S: AsyncRead + AsyncWrite + Unpin + Send,
 {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before REALITY HELLO")?
+        .as_secs();
+
     let mut control_frames: u32 = 0;
     let msg = next_handshake_binary(ws, &mut control_frames, "REALITY HELLO").await?;
 
-    if msg.len() < 1 + 32 + 8 {
-        bail!("short REALITY HELLO");
-    }
-    if msg[0] != REALITY_VERSION {
-        bail!("unsupported REALITY version: {}", msg[0]);
-    }
-
-    let client_pubkey: [u8; 32] = msg[1..33].try_into().unwrap();
-    let mut short_id = [0u8; 8];
-    short_id.copy_from_slice(&msg[33..41]);
-
-    validate_short_id(&short_id, cfg)?;
+    let hello = decode_client_hello(msg.as_ref())?;
+    validate_short_id(&hello.short_id, cfg)?;
+    reality_timestamp_in_window(now, hello.unix_secs, cfg.max_time_diff)?;
 
     // Reply with the pinned pubkey plus a MAC proving we hold the private
     // key (binds the X25519 shared secret to the transcript).
     let (response, shared) =
-        server_hello_with_confirm_and_shared(&cfg.private_key, &client_pubkey)?;
+        server_hello_with_confirm_and_shared(&cfg.private_key, &hello.client_pubkey)?;
     ws.send(Message::Binary(Bytes::from(response)))
         .await
         .context("send REALITY SERVER_HELLO")?;
@@ -395,10 +479,19 @@ where
     let server_pub = RealityServerConfig::public_key_from_private(&cfg.private_key);
     let auth = next_handshake_binary(ws, &mut control_frames, "REALITY client AUTH").await?;
     let got = decode_client_auth(auth.as_ref())?;
-    let expected = reality_client_auth_mac(&shared, token, &client_pubkey, &server_pub);
+    let expected = reality_client_auth_mac(
+        &shared,
+        token,
+        &hello.client_pubkey,
+        &server_pub,
+        hello.unix_secs,
+        &hello.nonce,
+    );
     if !bool::from(got[..].ct_eq(&expected[..])) {
         bail!("REALITY: client AUTH MAC invalid (unknown token)");
     }
+
+    replay_cache.check_and_insert(&hello.nonce, hello.unix_secs, now, cfg.max_time_diff)?;
     Ok(shared)
 }
 
@@ -453,13 +546,44 @@ pub async fn connect_reality_client(
     Ok(ws)
 }
 
-/// Encode REALITY client HELLO: `[version][ephemeral_pubkey:32][short_id:8]`.
-pub fn encode_client_hello(short_id: &[u8; 8], client_pubkey: &[u8; 32]) -> Vec<u8> {
-    let mut msg = Vec::with_capacity(1 + 32 + 8);
+/// Encode REALITY client HELLO v3:
+/// `[version][ephemeral_pubkey:32][short_id:8][unix_secs:8 BE][nonce:16]`.
+pub fn encode_client_hello(
+    short_id: &[u8; 8],
+    client_pubkey: &[u8; 32],
+    unix_secs: u64,
+    nonce: &[u8; 16],
+) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(REALITY_CLIENT_HELLO_LEN);
     msg.push(REALITY_VERSION);
     msg.extend_from_slice(client_pubkey);
     msg.extend_from_slice(short_id);
+    msg.extend_from_slice(&unix_secs.to_be_bytes());
+    msg.extend_from_slice(nonce);
     msg
+}
+
+/// Decode REALITY client HELLO v3.
+pub fn decode_client_hello(data: &[u8]) -> anyhow::Result<RealityClientHello> {
+    if data.len() < REALITY_CLIENT_HELLO_LEN {
+        bail!("short REALITY HELLO");
+    }
+    if data[0] != REALITY_VERSION {
+        bail!("unsupported REALITY version: {}", data[0]);
+    }
+    let mut client_pubkey = [0u8; 32];
+    client_pubkey.copy_from_slice(&data[1..33]);
+    let mut short_id = [0u8; 8];
+    short_id.copy_from_slice(&data[33..41]);
+    let unix_secs = u64::from_be_bytes(data[41..49].try_into().unwrap());
+    let mut nonce = [0u8; 16];
+    nonce.copy_from_slice(&data[49..65]);
+    Ok(RealityClientHello {
+        client_pubkey,
+        short_id,
+        unix_secs,
+        nonce,
+    })
 }
 
 /// Client REALITY HELLO + verify server pubkey (X25519 ephemeral), then send the
@@ -473,9 +597,21 @@ pub async fn reality_client_exchange_verify<S>(
 where
     S: AsyncRead + AsyncWrite + Unpin + Send,
 {
+    let unix_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before REALITY HELLO")?
+        .as_secs();
+    let mut nonce = [0u8; 16];
+    rand::rngs::OsRng.fill_bytes(&mut nonce);
+
     let ephemeral_secret = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
     let ephemeral_public = PublicKey::from(&ephemeral_secret);
-    let client_hello = encode_client_hello(short_id, ephemeral_public.as_bytes());
+    let client_hello = encode_client_hello(
+        short_id,
+        ephemeral_public.as_bytes(),
+        unix_secs,
+        &nonce,
+    );
     ws.send(Message::Binary(Bytes::from(client_hello)))
         .await
         .context("send REALITY client hello")?;
@@ -512,6 +648,8 @@ where
         token,
         ephemeral_public.as_bytes(),
         &server_pubkey,
+        unix_secs,
+        &nonce,
     );
     ws.send(Message::Binary(Bytes::from(encode_client_auth(&auth_mac))))
         .await
@@ -745,6 +883,8 @@ mod tests {
         let (priv_key, server_pub) = RealityServerConfig::generate_keys();
         let client_secret = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
         let client_public = PublicKey::from(&client_secret);
+        let unix_secs = 1_700_000_000;
+        let nonce = [9u8; 16];
 
         let (_hello, server_shared) =
             server_hello_with_confirm_and_shared(&priv_key, client_public.as_bytes()).unwrap();
@@ -756,12 +896,16 @@ mod tests {
             "s3cret-token",
             client_public.as_bytes(),
             &server_pub,
+            unix_secs,
+            &nonce,
         );
         let expected = reality_client_auth_mac(
             &server_shared,
             "s3cret-token",
             client_public.as_bytes(),
             &server_pub,
+            unix_secs,
+            &nonce,
         );
         assert_eq!(sent, expected);
 
@@ -778,14 +922,67 @@ mod tests {
         let (priv_key, server_pub) = RealityServerConfig::generate_keys();
         let client_secret = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
         let client_public = PublicKey::from(&client_secret);
+        let unix_secs = 1_700_000_000;
+        let nonce = [4u8; 16];
         let (_hello, shared) =
             server_hello_with_confirm_and_shared(&priv_key, client_public.as_bytes()).unwrap();
 
-        let forged =
-            reality_client_auth_mac(&shared, "guessed", client_public.as_bytes(), &server_pub);
-        let expected =
-            reality_client_auth_mac(&shared, "real-token", client_public.as_bytes(), &server_pub);
+        let forged = reality_client_auth_mac(
+            &shared,
+            "guessed",
+            client_public.as_bytes(),
+            &server_pub,
+            unix_secs,
+            &nonce,
+        );
+        let expected = reality_client_auth_mac(
+            &shared,
+            "real-token",
+            client_public.as_bytes(),
+            &server_pub,
+            unix_secs,
+            &nonce,
+        );
         assert_ne!(forged, expected);
+    }
+
+    #[test]
+    fn client_auth_mac_differs_when_timestamp_or_nonce_changes() {
+        let (priv_key, server_pub) = RealityServerConfig::generate_keys();
+        let client_secret = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
+        let client_public = PublicKey::from(&client_secret);
+        let (_hello, shared) =
+            server_hello_with_confirm_and_shared(&priv_key, client_public.as_bytes()).unwrap();
+        let base = reality_client_auth_mac(
+            &shared,
+            "token",
+            client_public.as_bytes(),
+            &server_pub,
+            100,
+            &[1u8; 16],
+        );
+        assert_ne!(
+            base,
+            reality_client_auth_mac(
+                &shared,
+                "token",
+                client_public.as_bytes(),
+                &server_pub,
+                101,
+                &[1u8; 16],
+            )
+        );
+        assert_ne!(
+            base,
+            reality_client_auth_mac(
+                &shared,
+                "token",
+                client_public.as_bytes(),
+                &server_pub,
+                100,
+                &[2u8; 16],
+            )
+        );
     }
 
     /// Replaying a captured AUTH frame into another session fails: the MAC is
@@ -794,20 +991,34 @@ mod tests {
     fn client_auth_mac_rejects_other_session_key() {
         let (priv_key, server_pub) = RealityServerConfig::generate_keys();
         let token = "real-token";
+        let unix_secs = 1_700_000_000;
+        let nonce = [6u8; 16];
 
         let first_client = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
         let first_pub = PublicKey::from(&first_client);
         let (_h1, first_shared) =
             server_hello_with_confirm_and_shared(&priv_key, first_pub.as_bytes()).unwrap();
-        let captured =
-            reality_client_auth_mac(&first_shared, token, first_pub.as_bytes(), &server_pub);
+        let captured = reality_client_auth_mac(
+            &first_shared,
+            token,
+            first_pub.as_bytes(),
+            &server_pub,
+            unix_secs,
+            &nonce,
+        );
 
         let second_client = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
         let second_pub = PublicKey::from(&second_client);
         let (_h2, second_shared) =
             server_hello_with_confirm_and_shared(&priv_key, second_pub.as_bytes()).unwrap();
-        let expected =
-            reality_client_auth_mac(&second_shared, token, second_pub.as_bytes(), &server_pub);
+        let expected = reality_client_auth_mac(
+            &second_shared,
+            token,
+            second_pub.as_bytes(),
+            &server_pub,
+            unix_secs,
+            &nonce,
+        );
 
         assert_ne!(captured, expected);
     }
@@ -834,10 +1045,71 @@ mod tests {
     fn client_hello_wire_layout() {
         let sid = [7u8; 8];
         let pk = [3u8; 32];
-        let wire = encode_client_hello(&sid, &pk);
-        assert_eq!(wire.len(), 41);
+        let unix_secs = 1_700_000_123u64;
+        let nonce = [8u8; 16];
+        let wire = encode_client_hello(&sid, &pk, unix_secs, &nonce);
+        assert_eq!(wire.len(), REALITY_CLIENT_HELLO_LEN);
         assert_eq!(wire[0], REALITY_VERSION);
         assert_eq!(&wire[1..33], &pk);
         assert_eq!(&wire[33..41], &sid);
+        assert_eq!(u64::from_be_bytes(wire[41..49].try_into().unwrap()), unix_secs);
+        assert_eq!(&wire[49..65], &nonce);
+
+        let decoded = decode_client_hello(&wire).unwrap();
+        assert_eq!(decoded.client_pubkey, pk);
+        assert_eq!(decoded.short_id, sid);
+        assert_eq!(decoded.unix_secs, unix_secs);
+        assert_eq!(decoded.nonce, nonce);
+
+        assert!(decode_client_hello(&wire[..64]).is_err());
+        let mut bad_ver = wire.clone();
+        bad_ver[0] = REALITY_VERSION.wrapping_sub(1);
+        assert!(decode_client_hello(&bad_ver).is_err());
+    }
+
+    #[test]
+    fn reality_timestamp_in_window_accepts_and_rejects() {
+        let max = 90u64;
+        let now = 1_000_000u64;
+        reality_timestamp_in_window(now, now, max).unwrap();
+        reality_timestamp_in_window(now, now - max, max).unwrap();
+        reality_timestamp_in_window(now, now + max, max).unwrap();
+        assert!(reality_timestamp_in_window(now, now - max - 1, max).is_err());
+        assert!(reality_timestamp_in_window(now, now + max + 1, max).is_err());
+    }
+
+    #[test]
+    fn replay_cache_rejects_duplicate_and_expires() {
+        let cache = RealityReplayCache::new();
+        let max = 90u64;
+        let hello_ts = 1_000u64;
+        let nonce = [1u8; 16];
+
+        cache
+            .check_and_insert(&nonce, hello_ts, hello_ts, max)
+            .unwrap();
+        assert!(cache
+            .check_and_insert(&nonce, hello_ts, hello_ts, max)
+            .is_err());
+
+        let after_window = hello_ts + max + 1;
+        cache
+            .check_and_insert(&nonce, hello_ts, after_window, max)
+            .unwrap();
+    }
+
+    #[test]
+    fn replay_cache_cap_does_not_grow_unbounded() {
+        let cache = RealityReplayCache::new();
+        let max = 3600u64;
+        let now = 10_000u64;
+        for i in 0..=REALITY_REPLAY_CACHE_CAP {
+            let mut nonce = [0u8; 16];
+            nonce[..8].copy_from_slice(&(i as u64).to_be_bytes());
+            cache
+                .check_and_insert(&nonce, now, now, max)
+                .unwrap();
+        }
+        assert!(cache.len() <= REALITY_REPLAY_CACHE_CAP);
     }
 }

--- a/bibavpn/tests/reality_handshake.rs
+++ b/bibavpn/tests/reality_handshake.rs
@@ -3,18 +3,25 @@
 
 use bibavpn::incoming::{accept_websocket_or_camouflage, CamouflageServeConfig};
 use bibavpn::reality::{
-    reality_client_exchange_verify, server_handshake_reality, RealityServerConfig, REALITY_VERSION,
+    encode_client_auth, encode_client_hello, reality_client_auth_mac,
+    reality_client_exchange_verify, server_handshake_reality, RealityReplayCache,
+    RealityServerConfig, REALITY_VERSION,
 };
 use bibavpn::stealth::{build_websocket_request, WsHandshakeParams};
 use bibavpn::tls_util::{install_ring_crypto, server_self_signed, TlsClientProfile};
 use futures_util::{SinkExt, StreamExt};
 use rustls::pki_types::ServerName;
 use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 use tokio_rustls::TlsAcceptor;
 use tokio_tungstenite::client_async;
 use tokio_tungstenite::tungstenite::Message;
+use x25519_dalek::{EphemeralSecret, PublicKey};
+
+const MAX_TIME_DIFF: u64 = 90;
 
 fn reality_cfg_for(priv_key: [u8; 32], short_ids: Vec<[u8; 8]>) -> RealityServerConfig {
     RealityServerConfig {
@@ -24,8 +31,15 @@ fn reality_cfg_for(priv_key: [u8; 32], short_ids: Vec<[u8; 8]>) -> RealityServer
         short_ids,
         min_client_ver: None,
         max_client_ver: None,
-        max_time_diff: 0,
+        max_time_diff: MAX_TIME_DIFF,
     }
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_secs()
 }
 
 /// Accept one TLS + WSS connection and run the server side of the REALITY
@@ -34,6 +48,7 @@ async fn spawn_reality_server(
     cfg: RealityServerConfig,
     ws_path: &str,
     token: &str,
+    replay_cache: Arc<RealityReplayCache>,
 ) -> (SocketAddr, JoinHandle<anyhow::Result<[u8; 32]>>) {
     let tls_cfg = server_self_signed("127.0.0.1").expect("self-signed");
     let acceptor = TlsAcceptor::from(tls_cfg);
@@ -56,9 +71,51 @@ async fn spawn_reality_server(
         .await
         .expect("ws")
         .expect("ws some");
-        let res = server_handshake_reality(&mut ws, &cfg, &token).await;
+        let res = server_handshake_reality(&mut ws, &cfg, &token, &replay_cache).await;
         let _ = ws.close(None).await;
         res
+    });
+    (addr, handle)
+}
+
+async fn spawn_reality_server_loop(
+    cfg: RealityServerConfig,
+    ws_path: &str,
+    token: &str,
+    replay_cache: Arc<RealityReplayCache>,
+    connections: usize,
+) -> (
+    SocketAddr,
+    JoinHandle<Vec<anyhow::Result<[u8; 32]>>>,
+) {
+    let tls_cfg = server_self_signed("127.0.0.1").expect("self-signed");
+    let acceptor = TlsAcceptor::from(tls_cfg);
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+
+    let ws_path = ws_path.to_string();
+    let token = token.to_string();
+    let handle = tokio::spawn(async move {
+        let mut results = Vec::with_capacity(connections);
+        for _ in 0..connections {
+            let (tcp, _) = listener.accept().await.expect("accept");
+            let tls = acceptor.accept(tcp).await.expect("tls accept");
+            let (mut ws, _) = accept_websocket_or_camouflage(
+                tls,
+                &ws_path,
+                false,
+                &token,
+                CamouflageServeConfig::default(),
+                None,
+            )
+            .await
+            .expect("ws")
+            .expect("ws some");
+            let res = server_handshake_reality(&mut ws, &cfg, &token, &replay_cache).await;
+            let _ = ws.close(None).await;
+            results.push(res);
+        }
+        results
     });
     (addr, handle)
 }
@@ -95,9 +152,15 @@ async fn reality_handshake_over_wss() {
     let (priv_key, pub_key) = RealityServerConfig::generate_keys();
     let short_id = reality_cfg_for(priv_key, vec![]).generate_short_id();
     let token = "test-token";
+    let replay_cache = Arc::new(RealityReplayCache::new());
 
-    let (addr, server) =
-        spawn_reality_server(reality_cfg_for(priv_key, vec![short_id]), "/ws", token).await;
+    let (addr, server) = spawn_reality_server(
+        reality_cfg_for(priv_key, vec![short_id]),
+        "/ws",
+        token,
+        Arc::clone(&replay_cache),
+    )
+    .await;
     let mut ws = client_ws(addr, "/ws").await;
 
     let session_key = reality_client_exchange_verify(&mut ws, &pub_key, &short_id, token)
@@ -122,11 +185,13 @@ async fn reality_handshake_rejects_wrong_token() {
 
     let (priv_key, pub_key) = RealityServerConfig::generate_keys();
     let short_id = [0u8; 8];
+    let replay_cache = Arc::new(RealityReplayCache::new());
 
     let (addr, server) = spawn_reality_server(
         reality_cfg_for(priv_key, vec![short_id]),
         "/ws",
         "right-token",
+        replay_cache,
     )
     .await;
     let mut ws = client_ws(addr, "/ws").await;
@@ -151,19 +216,20 @@ async fn reality_handshake_rejects_missing_auth() {
 
     let (priv_key, _pub_key) = RealityServerConfig::generate_keys();
     let short_id = [0u8; 8];
+    let replay_cache = Arc::new(RealityReplayCache::new());
 
     let (addr, server) = spawn_reality_server(
         reality_cfg_for(priv_key, vec![short_id]),
         "/ws",
         "test-token",
+        replay_cache,
     )
     .await;
     let mut ws = client_ws(addr, "/ws").await;
 
-    // Raw HELLO, no AUTH: send a plaintext MUX_OPEN instead.
-    let mut hello = vec![REALITY_VERSION];
-    hello.extend_from_slice(&[7u8; 32]);
-    hello.extend_from_slice(&short_id);
+    let now = unix_now();
+    let nonce = [7u8; 16];
+    let hello = encode_client_hello(&short_id, &[7u8; 32], now, &nonce);
     ws.send(Message::Binary(hello.into())).await.expect("hello");
     let _server_hello = ws.next().await;
     ws.send(Message::Binary(
@@ -176,6 +242,150 @@ async fn reality_handshake_rejects_missing_auth() {
     assert!(
         res.is_err(),
         "server must reject an application frame in place of REALITY AUTH"
+    );
+    let _ = ws.close(None).await;
+}
+
+/// Resending captured HELLO + AUTH bytes on a second connection must fail.
+#[tokio::test]
+async fn reality_handshake_rejects_replayed_bytes() {
+    install_ring_crypto();
+
+    let (priv_key, pub_key) = RealityServerConfig::generate_keys();
+    let short_id = [0u8; 8];
+    let token = "replay-token";
+    let replay_cache = Arc::new(RealityReplayCache::new());
+    let cfg = reality_cfg_for(priv_key, vec![short_id]);
+
+    let now = unix_now();
+    let client_secret = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
+    let client_public = PublicKey::from(&client_secret);
+    let nonce = [0xab; 16];
+    let hello = encode_client_hello(&short_id, client_public.as_bytes(), now, &nonce);
+
+    let server_public = PublicKey::from(pub_key);
+    let shared = client_secret.diffie_hellman(&server_public);
+    let auth_mac = reality_client_auth_mac(
+        shared.as_bytes(),
+        token,
+        client_public.as_bytes(),
+        &pub_key,
+        now,
+        &nonce,
+    );
+    let auth = encode_client_auth(&auth_mac);
+
+    let (addr, server) =
+        spawn_reality_server_loop(cfg, "/ws", token, Arc::clone(&replay_cache), 2).await;
+
+    let mut ws1 = client_ws(addr, "/ws").await;
+    ws1.send(Message::Binary(hello.clone().into()))
+        .await
+        .expect("hello");
+    let _ = ws1.next().await;
+    ws1.send(Message::Binary(auth.clone().into()))
+        .await
+        .expect("auth");
+    let _ = ws1.close(None).await;
+
+    let mut ws2 = client_ws(addr, "/ws").await;
+    ws2.send(Message::Binary(hello.into())).await.expect("replay hello");
+    let _ = ws2.next().await;
+    ws2.send(Message::Binary(auth.into()))
+        .await
+        .expect("replay auth");
+    let _ = ws2.close(None).await;
+
+    let results = server.await.expect("join");
+    assert!(results[0].is_ok(), "first handshake must succeed");
+    assert!(
+        results[1].is_err(),
+        "replayed HELLO + AUTH must be rejected: {:?}",
+        results[1]
+    );
+    let err = results[1].as_ref().unwrap_err().to_string();
+    assert!(
+        err.contains("replay") || err.contains("nonce"),
+        "expected replay error, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn reality_handshake_rejects_stale_timestamp() {
+    install_ring_crypto();
+
+    let (priv_key, _pub_key) = RealityServerConfig::generate_keys();
+    let short_id = [0u8; 8];
+    let replay_cache = Arc::new(RealityReplayCache::new());
+
+    let (addr, server) = spawn_reality_server(
+        reality_cfg_for(priv_key, vec![short_id]),
+        "/ws",
+        "test-token",
+        replay_cache,
+    )
+    .await;
+    let mut ws = client_ws(addr, "/ws").await;
+
+    let stale = unix_now().saturating_sub(MAX_TIME_DIFF + 1);
+    let hello = encode_client_hello(&short_id, &[1u8; 32], stale, &[2u8; 16]);
+    ws.send(Message::Binary(hello.into())).await.expect("hello");
+
+    let res = server.await.expect("join");
+    assert!(res.is_err(), "stale HELLO must be rejected");
+    let err = res.unwrap_err().to_string();
+    assert!(
+        err.contains("timestamp") || err.contains("window") || err.contains("skew"),
+        "expected timestamp/window error, got: {err}"
+    );
+    let _ = ws.close(None).await;
+}
+
+#[tokio::test]
+async fn reality_handshake_accepts_timestamp_within_window() {
+    install_ring_crypto();
+
+    let (priv_key, pub_key) = RealityServerConfig::generate_keys();
+    let short_id = [0u8; 8];
+    let token = "skew-token";
+    let replay_cache = Arc::new(RealityReplayCache::new());
+
+    let (addr, server) = spawn_reality_server(
+        reality_cfg_for(priv_key, vec![short_id]),
+        "/ws",
+        token,
+        Arc::clone(&replay_cache),
+    )
+    .await;
+    let mut ws = client_ws(addr, "/ws").await;
+
+    let skewed = unix_now().saturating_sub(MAX_TIME_DIFF);
+    let client_secret = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
+    let client_public = PublicKey::from(&client_secret);
+    let nonce = [3u8; 16];
+    let hello = encode_client_hello(&short_id, client_public.as_bytes(), skewed, &nonce);
+    ws.send(Message::Binary(hello.into())).await.expect("hello");
+
+    let _server_msg = ws.next().await.expect("server hello").expect("binary");
+    let server_public = PublicKey::from(pub_key);
+    let shared = client_secret.diffie_hellman(&server_public);
+    let auth_mac = reality_client_auth_mac(
+        shared.as_bytes(),
+        token,
+        client_public.as_bytes(),
+        &pub_key,
+        skewed,
+        &nonce,
+    );
+    ws.send(Message::Binary(encode_client_auth(&auth_mac).into()))
+        .await
+        .expect("auth");
+
+    let res = server.await.expect("join");
+    assert!(
+        res.is_ok(),
+        "HELLO within max_time_diff must succeed: {:?}",
+        res
     );
     let _ = ws.close(None).await;
 }


### PR DESCRIPTION
Closes #31

Automated agent-fix. Linked to issue #31. Draft — do not merge without a human review.

Review: PASS