### PR TITLE
fix(desktop): keep tray, exit and deep-link off the main thread

### DIFF
--- a/apps/bibavpn-desktop/src-tauri/src/lib.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/lib.rs
@@ -323,19 +323,33 @@ fn apply_tray_menu_locale(
     Ok(())
 }
 
+/// Импорт по ссылке всегда уходит с главного потока.
+///
+/// [`handle_import_deeplink`] делает блокирующий HTTP-запрос к control plane
+/// (`ureq`, по 20 с на connect и на read), а попасть сюда можно только с
+/// главного потока: из `setup()` при запуске по ссылке и из `RunEvent::Opened`
+/// на macOS (Rust-слушатели `emit` вызываются инлайн на потоке-эмитенте).
+/// Синхронный вызов замораживал окно на всё время запроса, а на старте —
+/// задерживал его появление.
+fn spawn_import_deeplink(state: AppState, app: AppHandle, raw_url: String) {
+    std::thread::spawn(move || {
+        if let Err(e) = handle_import_deeplink(&state, &app, &raw_url) {
+            warn!(target: "bibavpn_desktop", "deep link: {e}");
+            let mut g = state.inner.lock().unwrap_or_else(|p| p.into_inner());
+            g.last_error = Some(e);
+            let snap = snapshot(&app, &g);
+            drop(g);
+            let _ = app.emit("vpn-state", &snap);
+        }
+    });
+}
+
 fn install_deep_link_handler(app: &AppHandle, state: AppState) {
     let handle = app.clone();
     let st = state.clone();
     app.deep_link().on_open_url(move |event| {
         for url in event.urls() {
-            let raw = url.to_string();
-            if let Err(e) = handle_import_deeplink(&st, &handle, &raw) {
-                warn!(target: "bibavpn_desktop", "deep link: {e}");
-                let mut g = st.inner.lock().unwrap_or_else(|p| p.into_inner());
-                g.last_error = Some(e);
-                let snap = snapshot(&handle, &g);
-                let _ = handle.emit("vpn-state", &snap);
-            }
+            spawn_import_deeplink(st.clone(), handle.clone(), url.to_string());
         }
     });
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -344,10 +358,7 @@ fn install_deep_link_handler(app: &AppHandle, state: AppState) {
     }
     if let Ok(Some(urls)) = app.deep_link().get_current() {
         for url in urls {
-            let raw = url.to_string();
-            if let Err(e) = handle_import_deeplink(&state, app, &raw) {
-                warn!(target: "bibavpn_desktop", "deep link startup: {e}");
-            }
+            spawn_import_deeplink(state.clone(), app.clone(), url.to_string());
         }
     }
 }
@@ -583,6 +594,50 @@ fn spawn_tunnel_recovery_watch(app: AppHandle, state: AppState) {
         }
         }
     });
+}
+
+/// Подключение из трея — тоже вне главного потока.
+///
+/// Обработчики меню трея Tauri вызываются инлайн из event loop
+/// (`muda::MenuEvent` → `RunEvent::MenuEvent` → слушатели), то есть на главном
+/// потоке. [`connect_inner`] ждёт готовности локального прокси и туннеля до 45 с,
+/// плюс HTTP за списками обхода, запись конфига и подпроцессы системного прокси;
+/// прямой вызов из трея подвешивал окно, IPC и сам трей на всё это время.
+/// IPC-команды [`connect_cmd`] / [`disconnect_cmd`] уже уходят с главного потока
+/// через `spawn_blocking` — трей обязан вести себя так же.
+///
+/// Отдельный поток, а не blocking-пул `tauri::async_runtime`: пул делят
+/// `connect_cmd`, `disconnect_cmd`, `get_bypass_presets_cmd` и RTT-пробы раз в
+/// 8 с, а здесь работа редкая и долгая — как у watchdog и prefetch рядом.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn spawn_tray_connect(state: AppState, app: AppHandle) {
+    std::thread::spawn(move || {
+        let failed = match connect_inner(&state, &app) {
+            Ok(()) => false,
+            Err(e) => {
+                warn!(target: "bibavpn_desktop", "подключение из трея: {e}");
+                let mut g = state.inner.lock().unwrap_or_else(|p| p.into_inner());
+                g.last_error = Some(e);
+                true
+            }
+        };
+        let g = state.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let snap = snapshot(&app, &g);
+        drop(g);
+        let _ = app.emit("vpn-state", &snap);
+        if failed {
+            show_main_window(&app);
+        }
+    });
+}
+
+/// Отключение из трея: [`disconnect_inner`] блокируется на восстановлении
+/// системного прокси (ретраи со sleep + подпроцессы) и до 5 с на остановке
+/// клиента, поэтому с главного потока его тоже вызывать нельзя.
+/// Актуальный `vpn-state` он отправляет сам в конце.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn spawn_tray_disconnect(state: AppState, app: AppHandle) {
+    std::thread::spawn(move || disconnect_inner(&state, &app, true));
 }
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -1676,34 +1731,23 @@ pub fn run() -> anyhow::Result<()> {
                     .on_menu_event(move |app, event| match event.id.as_ref() {
                         "show" => show_main_window(app),
                         "quit" => {
-                            let st = app.state::<AppState>();
-                            disconnect_inner(&*st, app, true);
+                            // Teardown делает единственный обработчик `RunEvent::Exit`:
+                            // `AppHandle::exit` гарантированно доставляет
+                            // `ExitRequested` + `Exit`. Раньше `disconnect_inner`
+                            // вызывался и здесь, и там — прокси восстанавливался
+                            // дважды, причём второй проход шёл уже без снимка
+                            // настроек (`proxy_backup` забран первым) и вслепую
+                            // дёргал `gsettings` / `networksetup` ещё раз.
                             app.exit(0);
                         }
-                        "on" => {
-                            let st = app.state::<AppState>();
-                            let h = app.clone();
-                            if let Err(e) = connect_inner(&*st, &h) {
-                                warn!(target: "bibavpn_desktop", "подключение из трея: {e}");
-                                let mut g = st.inner.lock().unwrap_or_else(|e| e.into_inner());
-                                g.last_error = Some(e);
-                                let snap = snapshot(&h, &g);
-                                let _ = h.emit("vpn-state", &snap);
-                                show_main_window(&h);
-                            } else {
-                                let g = st.inner.lock().unwrap_or_else(|e| e.into_inner());
-                                let snap = snapshot(&h, &g);
-                                let _ = h.emit("vpn-state", &snap);
-                            }
-                        }
-                        "off" => {
-                            let st = app.state::<AppState>();
-                            let h = app.clone();
-                            disconnect_inner(&*st, &h, true);
-                            let g = st.inner.lock().unwrap_or_else(|e| e.into_inner());
-                            let snap = snapshot(&h, &g);
-                            let _ = h.emit("vpn-state", &snap);
-                        }
+                        "on" => spawn_tray_connect(
+                            Clone::clone(&*app.state::<AppState>()),
+                            app.clone(),
+                        ),
+                        "off" => spawn_tray_disconnect(
+                            Clone::clone(&*app.state::<AppState>()),
+                            app.clone(),
+                        ),
                         "logs" => {
                             if let Some(dir) = logging::logs_directory() {
                                 logging::open_in_file_manager(dir);
@@ -1785,6 +1829,12 @@ pub fn run() -> anyhow::Result<()> {
 
     app.run(|app_handle, event| {
         if let RunEvent::Exit = event {
+            // Единственная точка teardown на выходе, и она обязана быть
+            // синхронной: процесс умирает сразу после возврата, а системный
+            // прокси надо успеть вернуть — иначе пользователь останется без
+            // интернета. Отсюда же и цена выхода (восстановление прокси плюс
+            // до 5 с на остановку клиента), поэтому дублировать её из трея
+            // нельзя.
             let st = app_handle.state::<AppState>();
             disconnect_inner(&*st, app_handle, true);
         }


### PR DESCRIPTION
## Problem

Three entry points ran long blocking work directly on the Tauri main thread. The IPC command path was already hardened (`b4eb3ef` *avoid blocking UI during connect*, `278c06d` *do not hold the state Mutex during disconnect*) — these three were missed.

**1. Tray menu handlers.** Verified against tauri 2.10.3: menu events are pushed into the event loop (`app.rs:2199-2201`) and the listeners are invoked **inline on the event-loop thread** (`app.rs:2437-2451`). So `"on"` ran `connect_inner` and `"off"`/`"quit"` ran `disconnect_inner` on the main thread:

- `connect_inner` blocks on `socks_rx.recv_timeout(45 s)`, plus `bypass_domains::ensure_loaded` (HTTP), `persist_cfg` (disk) and `apply_proxy` (`gsettings` / `networksetup` subprocesses);
- `disconnect_inner` blocks on `restore_with_retry` (3 attempts with 250/500 ms sleeps + subprocesses) and then `vpn.stop()` → `rt.block_on(timeout(5 s))`.

Result: window, IPC bridge and the tray itself frozen for up to ~45–50 s. `connect_cmd` / `disconnect_cmd` wrap the very same functions in `spawn_blocking` — that asymmetry was the bug.

**2. Duplicated teardown on quit.** Tray `"quit"` called `disconnect_inner` and then `app.exit(0)`, which triggers `RunEvent::Exit` — where `disconnect_inner` runs again. The second pass sees `proxy_backup` already taken, falls into the `None` branch of `restore_proxy_blocking` and blindly re-runs the residual-proxy cleanup subprocesses.

**3. Deep-link import.** `handle_import_deeplink` does a blocking `ureq` POST with `timeout_connect(20 s)` + `timeout_read(20 s)`, and was called synchronously from `install_deep_link_handler` — which runs from `setup()`. Launching via `bibavpn://import?...` against a slow or dead control-plane host delayed the window appearing by up to ~40 s. The same body runs in the `on_open_url` callback, reached on macOS from `RunEvent::Opened` → `emit` → Rust listeners inline on the main thread. Since the host comes from the URL (see #64), the freeze duration is influenced by whoever supplied the link.

## Change

- `spawn_tray_connect` / `spawn_tray_disconnect` move the tray work to a dedicated thread. A plain `std::thread::spawn` rather than the `tauri::async_runtime` blocking pool, because that pool is shared with `connect_cmd`, `disconnect_cmd`, `get_bypass_presets_cmd` and the every-8 s RTT probes — and it matches how `spawn_tunnel_recovery_watch` and `prefetch_bypass_domains` already spawn long background work in this file.
- Tray `"quit"` is now just `app.exit(0)`. `AppHandle::exit` is documented to deliver `ExitRequested` + `Exit` (`app.rs:531`, dispatched at `app.rs:1304-1307`), so the single `RunEvent::Exit` handler owns the teardown.
- `spawn_import_deeplink` runs the import on its own thread, for both the `on_open_url` callback and the startup `get_current()` path.

The `RunEvent::Exit` teardown stays **synchronous** on purpose — the process exits right after it returns, and the system proxy has to be restored first or the user is left without internet. Comments were added at each site recording why.

Minor behaviour change: the startup deep-link path previously only logged failures; it now also sets `last_error` and emits `vpn-state`, matching what the `on_open_url` path already did.

## Verification

- `cargo clippy -p bibavpn-desktop --all-targets` — 0 errors, and no new warnings: the remaining ones are exactly the pre-existing set on `main` (only line numbers shifted). The first attempt used `let _ = spawn_blocking(...)` and tripped `clippy::let_underscore_future`; that is what prompted the move to `std::thread::spawn`.
- `cargo test -p bibavpn-desktop --locked` — 23 passed, 0 failed.
- Not done: runtime smoke of the tray / quit / deep-link paths. It needs a desktop session, and a second instance would contend with the running client over the system proxy and ports 17890/17891. Worth a manual pass before merge.
- Mobile targets not compiled locally (no Android target installed); the Android/iOS workflows cover them. The only change outside `#[cfg(not(android/ios))]` is `spawn_import_deeplink`, which uses APIs already used on the mobile paths in this file.

## Not addressed here

Found while investigating, left out to keep this focused — happy to file them as issues:

- `VPN_WEBVIEW_JNI_MUTEX` (`android_vpn.rs:16-35`) is released when `with_main_webview_jni` returns, i.e. right after the closure is *posted*; the actual JNI call runs later on the UI thread and the caller waits on `rx.recv_timeout` outside the guard. So it does not serialise what the comment on line 13 says must be serialised. The #79 fix (`6d5523d`) only touched `TauriVpnBridge.kt`.
- `snapshot()` does JNI round-trips (two 5 s timeouts) while the `Inner` mutex is held, at every call site on mobile.
- The 2 s timeout in `get_bypass_presets_cmd` wraps a `spawn_blocking` handle, so it does not cancel the fetch — the thread keeps running.
- `measure_tcp_connect_rtt_ms` bounds `connect_timeout` but not the blocking `to_socket_addrs()` DNS lookup, and it is polled every 8 s onto the shared blocking pool.
- Pre-existing race, now slightly easier to hit from the tray: `disconnect_inner` does not wait for an in-flight `connect_inner`, so a connect that is already past the phase check can re-apply the system proxy after teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
