### PR TITLE
ci(agent-fix): only run on issues opened by the repo owner

### DIFF
--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -1,3 +1,7 @@
+# Only issues opened by the repo owner can spawn the agent (see the `if:` on the
+# job). Someone else's issue does nothing even when labelled; use
+# `workflow_dispatch` if you really want to run the agent on it.
+#
 # Label an issue `agent-fix` (or run manually with the issue number) to spawn:
 #   1. Grok 4.6 (standard, not Fast) classifies SMALL bug vs LARGE feature
 #      - LARGE: posts a proposal, @-mentions the owner, stops (no code)
@@ -56,9 +60,16 @@ env:
 jobs:
   fix:
     name: spec → implement → review
+    # Only the repo owner's own issues may spawn the agent. Labelling already
+    # needs write access, but the issue *body* is the agent's prompt and is
+    # treated as untrusted input, so an outside contributor must not be able to
+    # get code written and a PR opened from text they authored.
+    # `workflow_dispatch` stays open as the manual escape hatch — it needs write
+    # access too, and that is the owner-approved path for LARGE features.
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.issue.pull_request == null &&
+       github.event.issue.user.login == github.repository_owner &&
        (github.event.label.name == 'agent-fix' ||
         github.event.label.name == 'agent-implement'))
     runs-on: ubuntu-latest


### PR DESCRIPTION
Requested: the agent must not open PRs off other people's issues.

The job previously triggered on any issue that got the `agent-fix` /
`agent-implement` label. The issue body is the agent's prompt and the workflow
header already says it is treated as untrusted (prompt injection), so an
outside contributor's text could end up driving the agent and producing a PR.

Now the job also requires `github.event.issue.user.login == github.repository_owner`.
Someone else's issue does nothing even when labelled.

`workflow_dispatch` is deliberately left open — it needs write access anyway,
and it is the documented owner-approved path for LARGE features
(`force_implement`).

YAML parses; the change is a single added clause in the job's `if:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)