### PR TITLE
ci(desktop): bundle with tauri build so the app icon ships

### DIFF
--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -46,7 +46,12 @@ jobs:
           sudo apt-get install -y -qq \
             libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
             patchelf libssl-dev build-essential pkg-config \
-            libayatana-appindicator3-dev
+            libayatana-appindicator3-dev \
+            clang libclang-dev cmake file
+          # clang/libclang/cmake are for the `boring-tls` feature: `tauri build`
+          # honours `build.features` in tauri.conf.json, so unlike the previous
+          # plain `cargo build` this compiles BoringSSL, whose bindgen step needs
+          # libclang. `file` is required by linuxdeploy for the AppImage.
 
       - name: Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -69,18 +74,27 @@ jobs:
           BIBA_BYPASS_DOMAINS_REQUIRED: ${{ github.event_name == 'workflow_call' && '1' || '0' }}
         run: bash .github/scripts/ci-fetch-bypass-domains.sh
 
-      - name: Build bibavpn-desktop (release)
-        run: cargo build -p bibavpn-desktop --release
+      # `tauri build` (not a bare `cargo build`) is what consumes `bundle.icon`
+      # from tauri.conf.json. It emits usr/share/applications/BibaVPN.desktop
+      # with Icon=/StartupWMClass=bibavpn-desktop plus the hicolor PNGs, which is
+      # what makes the launcher/dock icon appear. A raw binary has nothing for
+      # the shell to hang an icon on — only the tray icon worked, because that
+      # one is include_image!'d into the executable.
+      - name: Build bundles (deb + AppImage)
+        working-directory: apps/bibavpn-desktop
+        run: npx --yes @tauri-apps/cli@2 build --bundles deb,appimage
 
-      - name: Pack tarball
+      - name: Stage artifacts
         run: |
           set -euo pipefail
-          install -m 755 target/release/bibavpn-desktop BibaVPN-linux-x64
-          tar -czf BibaVPN-linux-x64.tar.gz BibaVPN-linux-x64
+          mkdir -p dist
+          cp target/release/bundle/deb/*.deb dist/
+          cp target/release/bundle/appimage/*.AppImage dist/
+          ls -la dist
 
-      - name: Upload tarball
+      - name: Upload bundles
         uses: actions/upload-artifact@v4
         with:
           name: BibaVPN-linux-x64
-          path: BibaVPN-linux-x64.tar.gz
+          path: dist/*
           if-no-files-found: error

--- a/.github/workflows/desktop-macos.yml
+++ b/.github/workflows/desktop-macos.yml
@@ -61,48 +61,23 @@ jobs:
           BIBA_BYPASS_DOMAINS_REQUIRED: ${{ github.event_name == 'workflow_call' && '1' || '0' }}
         run: bash .github/scripts/ci-fetch-bypass-domains.sh
 
-      - name: Build bibavpn-desktop (release)
-        run: cargo build -p bibavpn-desktop --release
+      # `tauri build` (not a bare `cargo build`) is what consumes `bundle.icon`
+      # from tauri.conf.json: it writes Contents/Resources/icon.icns and the
+      # matching CFBundleIconFile into Info.plist. The previous hand-rolled
+      # BibaVPN.app created an empty Resources/ and a plist with no
+      # CFBundleIconFile, so the Dock and Finder fell back to the generic icon —
+      # only the tray icon worked, because that one is include_image!'d into the
+      # executable. The hand-written plist had also drifted to version 0.1.0
+      # while tauri.conf.json said 0.2.0; the bundler keeps them in sync.
+      - name: Build bundles (.app + DMG)
+        working-directory: apps/bibavpn-desktop
+        run: npx --yes @tauri-apps/cli@2 build --bundles app,dmg
 
-      - name: Pack BibaVPN.app + DMG
+      - name: Stage DMG
         run: |
           set -euo pipefail
-          APP_DIR="packaging/BibaVPN.app"
-          BIN="$APP_DIR/Contents/MacOS/BibaVPN"
-          mkdir -p "$(dirname "$BIN")" "$APP_DIR/Contents/Resources"
-          cp target/release/bibavpn-desktop "$BIN"
-          chmod +x "$BIN"
-          cat > "$APP_DIR/Contents/Info.plist" <<'EOF'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-            <key>CFBundleExecutable</key>
-            <string>BibaVPN</string>
-            <key>CFBundleIdentifier</key>
-            <string>dev.bibavpn.desktop</string>
-            <key>CFBundleName</key>
-            <string>BibaVPN</string>
-            <key>CFBundlePackageType</key>
-            <string>APPL</string>
-            <key>CFBundleShortVersionString</key>
-            <string>0.1.0</string>
-            <key>CFBundleVersion</key>
-            <string>1</string>
-            <key>LSMinimumSystemVersion</key>
-            <string>11.0</string>
-            <key>NSHighResolutionCapable</key>
-            <true/>
-          </dict>
-          </plist>
-          EOF
-          STAGE="packaging/dmg_root"
-          rm -rf "$STAGE"
-          mkdir -p "$STAGE"
-          cp -R "$APP_DIR" "$STAGE/"
-          ln -sf /Applications "$STAGE/Applications"
-          rm -f BibaVPN-macos-aarch64.dmg
-          hdiutil create -volname "BibaVPN" -srcfolder "$STAGE" -ov -format UDZO BibaVPN-macos-aarch64.dmg
+          cp target/release/bundle/dmg/*.dmg BibaVPN-macos-aarch64.dmg
+          ls -la BibaVPN-macos-aarch64.dmg
 
       - name: Upload DMG
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,5 +103,6 @@ jobs:
           files: |
             dist/BibaVPN-macos-aarch64.dmg
             dist/BibaVPN-windows-x64.zip
-            dist/BibaVPN-linux-x64.tar.gz
+            dist/*.deb
+            dist/*.AppImage
             dist/BibaVPN-android-debug.apk


### PR DESCRIPTION
## Cause

Neither desktop workflow ever ran `tauri build`. Both did a plain `cargo build -p bibavpn-desktop --release` and then hand-rolled the packaging, so `bundle.icon` in `tauri.conf.json` — which only `tauri build` reads — was never consumed. The icon files themselves were all present and the config was correct; nothing executed it.

**macOS:** `BibaVPN.app` was assembled by hand. `Contents/Resources` was created and left empty (`icon.icns` never copied) and the hand-written `Info.plist` had no `CFBundleIconFile`, so Dock and Finder fell back to the generic icon. That plist had also drifted to `CFBundleShortVersionString` `0.1.0` while `tauri.conf.json` says `0.2.0`.

**Linux:** the artifact was a bare ELF in a tarball — no `.desktop`, no hicolor icons, nothing for the shell to attach an icon to.

**Why the tray was fine:** `tray_icon()` is `include_image!("icons/32x32.png")` — compiled into the executable and passed straight to the tray API, independent of bundling. That asymmetry is exactly the reported symptom.

## Change

Both workflows now run `tauri build`. Verified locally that the Linux bundle carries the icon — the deb installs:

```
usr/share/applications/BibaVPN.desktop      Icon=bibavpn-desktop, StartupWMClass=bibavpn-desktop
usr/share/icons/hicolor/32x32/apps/bibavpn-desktop.png
usr/share/icons/hicolor/128x128/apps/bibavpn-desktop.png
```

Two consequences handled here:

- `tauri build` honours `build.features`, so it enables `boring-tls`, which the previous bare `cargo build` did not. BoringSSL's bindgen step needs libclang, absent from the runner image — `clang`, `libclang-dev`, `cmake` added to the apt list, plus `file` for linuxdeploy. **Worth knowing:** shipped desktop builds now actually have the Boring TLS stack available, where `capabilities.boringTlsAvailable` was previously always false.
- The Linux artifact changes from a tarball to `.deb` + `.AppImage`, so `release.yml` no longer looks for `BibaVPN-linux-x64.tar.gz`.

## Deliberately not done

Not setting `app.enableGTKAppId`. It defaults to false, so tao passes `None` to `gtk::Application::new` and the Wayland `app_id` falls back to the program name `bibavpn-desktop` — which is what the generated `StartupWMClass` already matches. Turning it on would set the app_id to `dev.bibavpn.desktop` and **break** that match on Wayland compositors. (Checked on a Wayland/COSMIC session, where `_NET_WM_ICON` does not exist and desktop-file matching is the only mechanism.)

## Verification

Ran both Linux bundle targets locally end to end and inspected the output:

- `BibaVPN_0.2.0_amd64.deb` (5.9 MB) — contents listed above
- `BibaVPN_0.2.0_amd64.AppImage` (81 MB)

The `boring-tls` feature was toggled off for those local runs only, because this machine has no libclang; that is the exact gap the new apt packages close in CI. The macOS bundle path is not locally verifiable here and will get its first real exercise on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)