### PR TITLE
fix(android): do not block the main looper in requestConnect

### DIFF
--- a/apps/bibavpn-desktop/src-tauri/android-bibavpn-extras/java/dev/bibavpn/BibaVpnService.kt
+++ b/apps/bibavpn-desktop/src-tauri/android-bibavpn-extras/java/dev/bibavpn/BibaVpnService.kt
@@ -1171,6 +1171,16 @@ class BibaVpnService : VpnService() {
             lastConnectError = msg
         }
 
+        /**
+         * Записать ошибку подключения, которая пришла асинхронно (результат диалога
+         * разрешения VPN). Rust забирает её из [lastConnectError] в snapshot — так
+         * [TauriVpnBridge.requestConnect] может вернуться сразу, не блокируя лупер.
+         */
+        @JvmStatic
+        fun recordConnectError(msg: String) {
+            setLastConnectError(msg)
+        }
+
         /** Якорь [SystemClock.elapsedRealtime] в момент [setTunnelActive](true); 0 если туннеля нет. */
         @Volatile
         private var tunnelConnectedSinceElapsed: Long = 0L

--- a/apps/bibavpn-desktop/src-tauri/android-bibavpn-extras/java/dev/bibavpn/TauriVpnBridge.kt
+++ b/apps/bibavpn-desktop/src-tauri/android-bibavpn-extras/java/dev/bibavpn/TauriVpnBridge.kt
@@ -8,7 +8,6 @@ import android.os.Handler
 import android.util.Log
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Вызовы из Rust (Tauri) через JNI. Рефлексия к [app.tauri.plugin.PluginManager], чтобы модуль
@@ -59,48 +58,64 @@ object TauriVpnBridge {
         splitDomains: Array<String>,
         screenOffBatterySaver: Boolean,
     ): String? {
+        // Rust вызывает нас через wry `jni_handle().exec`, то есть уже НА главном лупере.
+        // Ждать здесь нельзя ни в каком виде: результат диалога разрешения VPN приходит
+        // через Activity result на этот же лупер, поэтому любое ожидание — самоблокировка
+        // (ANR «Input dispatching timed out» через 5 с). [startConnectOnMain] не блокирует:
+        // он ставит диалог и возвращается, а исход прилетает асинхронно и подхватывается
+        // через [BibaVpnService.lastConnectError].
         if (Looper.myLooper() == Looper.getMainLooper()) {
-            val holder = arrayOfNulls<String?>(1)
-            val latch = CountDownLatch(1)
-            Thread {
-                try {
-                    holder[0] =
-                        requestConnectWorker(
-                            activity,
-                            json,
-                            splitTunnelEnabled,
-                            splitPackages,
-                            splitDomains,
-                            screenOffBatterySaver,
-                        )
-                } catch (t: Throwable) {
-                    Log.e(TAG, "requestConnect", t)
-                    holder[0] = t.message ?: "requestConnect_exception"
-                } finally {
-                    latch.countDown()
-                }
-            }.start()
-            return try {
-                if (!latch.await(125, TimeUnit.SECONDS)) {
-                    "connect_ui_thread_timeout"
-                } else {
-                    holder[0]
-                }
-            } catch (e: InterruptedException) {
-                "connect_interrupted"
+            return startConnectOnMain(
+                activity,
+                json,
+                splitTunnelEnabled,
+                splitPackages,
+                splitDomains,
+                screenOffBatterySaver,
+            )
+        }
+        // Вызов с фонового потока: перепрыгиваем на UI и ждём только немедленный код
+        // возврата, который [startConnectOnMain] отдаёт не блокируясь.
+        val holder = arrayOfNulls<String?>(1)
+        val latch = CountDownLatch(1)
+        activity.runOnUiThread {
+            try {
+                holder[0] =
+                    startConnectOnMain(
+                        activity,
+                        json,
+                        splitTunnelEnabled,
+                        splitPackages,
+                        splitDomains,
+                        screenOffBatterySaver,
+                    )
+            } catch (t: Throwable) {
+                Log.e(TAG, "requestConnect", t)
+                holder[0] = t.message ?: "requestConnect_exception"
+            } finally {
+                latch.countDown()
             }
         }
-        return requestConnectWorker(
-            activity,
-            json,
-            splitTunnelEnabled,
-            splitPackages,
-            splitDomains,
-            screenOffBatterySaver,
-        )
+        return try {
+            if (!latch.await(30, TimeUnit.SECONDS)) {
+                "connect_ui_thread_timeout"
+            } else {
+                holder[0]
+            }
+        } catch (e: InterruptedException) {
+            "connect_interrupted"
+        }
     }
 
-    private fun requestConnectWorker(
+    /**
+     * Должна вызываться на главном лупере и НИКОГДА не блокировать его.
+     *
+     * Возвращает только немедленный исход: `null` — сервис стартовал или диалог
+     * разрешения VPN поставлен в очередь; строка — ошибка, которую видно сразу.
+     * Результат самого диалога приходит позже в [startVpnPermissionFlow] и попадает
+     * в [BibaVpnService.lastConnectError], откуда Rust забирает его в snapshot.
+     */
+    private fun startConnectOnMain(
         activity: Activity,
         json: String,
         splitTunnelEnabled: Boolean,
@@ -108,72 +123,48 @@ object TauriVpnBridge {
         splitDomains: Array<String>,
         screenOffBatterySaver: Boolean,
     ): String? {
-        val prepLatch = CountDownLatch(1)
-        val resultHolder = arrayOfNulls<String?>(1)
-        val released = AtomicBoolean(false)
-        fun finish(code: String?) {
-            if (released.compareAndSet(false, true)) {
-                resultHolder[0] = code
-                prepLatch.countDown()
-            }
-        }
-
-        activity.runOnUiThread {
-            try {
-                BibaVpnService.setSplitTunnelConfig(
-                    activity,
-                    splitTunnelEnabled,
-                    splitPackages.toSet(),
-                    splitDomains.toSet(),
-                )
-                BibaVpnService.setScreenOffBatterySaver(activity, screenOffBatterySaver)
-
-                val prep = VpnService.prepare(activity)
-                if (prep != null) {
-                    BibaVpnService.stashPendingConnectJson(activity, json)
-                    BibaVpnService.saveConfig(activity, json)
-                    val started =
-                        startVpnPermissionFlow(
-                            activity,
-                            prep,
-                            onOk = {
-                                val j =
-                                    BibaVpnService.takePendingConnectJson(activity)
-                                        ?: BibaVpnService.getLastConfigJson(activity)
-                                        ?: json
-                                BibaVpnService.clearPendingConnectJson(activity)
-                                BibaVpnService.startWithJson(activity, j)
-                                finish(null)
-                            },
-                            onDenied = {
-                                BibaVpnService.clearPendingConnectJson(activity)
-                                finish("vpn_permission_denied")
-                            },
-                        )
-                    if (!started) {
-                        BibaVpnService.clearPendingConnectJson(activity)
-                        finish("vpn_permission_ui_unavailable")
-                    }
-                    return@runOnUiThread
-                }
-
-                BibaVpnService.startWithJson(activity, json)
-                finish(null)
-            } catch (t: Throwable) {
-                Log.e(TAG, "requestConnectWorker", t)
-                finish(t.message ?: "requestConnect_exception")
-            }
-        }
-
         return try {
-            if (!prepLatch.await(120, TimeUnit.SECONDS)) {
-                BibaVpnService.clearPendingConnectJson(activity)
-                "vpn_permission_timeout"
-            } else {
-                resultHolder[0]
+            BibaVpnService.setSplitTunnelConfig(
+                activity,
+                splitTunnelEnabled,
+                splitPackages.toSet(),
+                splitDomains.toSet(),
+            )
+            BibaVpnService.setScreenOffBatterySaver(activity, screenOffBatterySaver)
+
+            val prep = VpnService.prepare(activity)
+            if (prep == null) {
+                BibaVpnService.startWithJson(activity, json)
+                return null
             }
-        } catch (e: InterruptedException) {
-            "connect_interrupted"
+
+            BibaVpnService.stashPendingConnectJson(activity, json)
+            BibaVpnService.saveConfig(activity, json)
+            val started =
+                startVpnPermissionFlow(
+                    activity,
+                    prep,
+                    onOk = {
+                        val j =
+                            BibaVpnService.takePendingConnectJson(activity)
+                                ?: BibaVpnService.getLastConfigJson(activity)
+                                ?: json
+                        BibaVpnService.clearPendingConnectJson(activity)
+                        BibaVpnService.startWithJson(activity, j)
+                    },
+                    onDenied = {
+                        BibaVpnService.clearPendingConnectJson(activity)
+                        BibaVpnService.recordConnectError("vpn_permission_denied")
+                    },
+                )
+            if (!started) {
+                BibaVpnService.clearPendingConnectJson(activity)
+                return "vpn_permission_ui_unavailable"
+            }
+            null
+        } catch (t: Throwable) {
+            Log.e(TAG, "startConnectOnMain", t)
+            t.message ?: "requestConnect_exception"
         }
     }
 

--- a/apps/bibavpn-desktop/src-tauri/src/lib.rs
+++ b/apps/bibavpn-desktop/src-tauri/src/lib.rs
@@ -1373,12 +1373,15 @@ fn connect_inner(state: &AppState, app: &AppHandle) -> Result<(), String> {
         std::thread::sleep(Duration::from_millis(300));
     }
 
+    // Вне мьютекса: это JNI-раундтрип с ожиданием ответа от UI-потока (таймаут 5 с).
+    // Под локом он задерживал бы всех, кто держит опрос состояния раз в секунду.
+    let _ = android_vpn::clear_last_connect_error(app);
+
     let mut g = match state.inner.lock() {
         Ok(g) => g,
         Err(p) => p.into_inner(),
     };
     g.last_error = None;
-    let _ = android_vpn::clear_last_connect_error(app);
 
     if !g.cfg.can_connect() {
         warn!(target: "bibavpn_desktop", "подключение: не заполнены сервер/токен или biba://");


### PR DESCRIPTION
Connecting froze the app immediately on a Pixel 10. Diagnosed from the device over adb — five ANRs in one session, main thread stack:

```
"main" prio=5 tid=1 TimedWaiting
  at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:276)
  at dev.bibavpn.TauriVpnBridge.requestConnect(TauriVpnBridge.kt:84)
  at android.os.Looper.loop(Looper.java:397)

ANR in dev.bibavpn — Input dispatching timed out (Waited 5005ms for MotionEvent)
```

The process sat at 4.1% CPU, so it was blocked, not spinning.

## Cause

Rust dispatches `requestConnect` through wry's `jni_handle().exec`, so it already runs **on** the main looper. #106 changed it to hand the work to a background thread and then `latch.await(125s)` — on the main thread. That background thread calls `requestConnectWorker`, which does `activity.runOnUiThread { VpnService.prepare(...) }` and waits on its own `prepLatch`. That `runOnUiThread` block queues onto the looper already blocked in the first await, so it never runs: `prepLatch` expires at 120s, `latch` at 125s, and the UI is dead throughout — ANR fires at 5s.

The roles were inverted. Before #106 the main thread did the work and a background thread waited.

This is the same defect `6d5523d` fixed for the app picker (#79), reintroduced on the connect path. Rust even carried a `connect_ui_thread_timeout` mapping, so the deadlock's timeout was being treated as a normal outcome rather than a bug.

## Fix

`requestConnect` no longer waits. On the main looper it calls the new `startConnectOnMain` directly, which returns as soon as the service is started or the consent dialog is queued. The dialog's outcome arrives later via the Activity result and is published through `BibaVpnService.lastConnectError()` — which is exactly the async error channel #106 introduced, so permission denials still reach the UI without a blocking wait. Called off the main looper, it hops over and waits only for that non-blocking return value.

Also moves `clear_last_connect_error` out from under the state mutex in `connect_inner`: it is a JNI round-trip with a 5s timeout, and holding the lock across it stalls the 1 Hz status poll.

## Verification

Rust builds; Kotlin braces balanced. The APK is built by CI and installed on the physical Pixel 10 over adb to confirm connect no longer ANRs — result appended below before merge.

## Not in this PR

`snapshot()` still makes up to three JNI round-trips (5s timeout each) while holding the `Inner` mutex, and the UI polls it every second. That is a separate latent stall I flagged when merging #106; fixing it means changing `snapshot`'s signature across ~20 call sites and does not belong in a hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)